### PR TITLE
Hide API request routes behind /api

### DIFF
--- a/backend/src/main/kotlin/com/climatechangemakers/act/di/ServiceModule.kt
+++ b/backend/src/main/kotlin/com/climatechangemakers/act/di/ServiceModule.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.json.Json
 import okhttp3.MediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
-import javax.inject.Named
 
 @Module object ServiceModule {
 

--- a/backend/src/main/kotlin/com/climatechangemakers/act/feature/action/routing/ActionRoutes.kt
+++ b/backend/src/main/kotlin/com/climatechangemakers/act/feature/action/routing/ActionRoutes.kt
@@ -2,10 +2,11 @@ package com.climatechangemakers.act.feature.action.routing
 
 import com.climatechangemakers.act.feature.action.controller.ActionController
 import io.ktor.application.call
+import io.ktor.routing.Route
 import io.ktor.routing.Routing
 import io.ktor.routing.post
 
-fun Routing.actionRoutes(controller: ActionController) {
+fun Route.actionRoutes(controller: ActionController) {
 
   post("/initiate-action") {
     controller.initiateAction(call)

--- a/backend/src/main/kotlin/com/climatechangemakers/act/plugins/Routing.kt
+++ b/backend/src/main/kotlin/com/climatechangemakers/act/plugins/Routing.kt
@@ -10,6 +10,8 @@ fun Application.configureRouting() {
   val apiComponent = DaggerApiComponent.create()
 
   routing {
-    actionRoutes(apiComponent.actionController())
+    route("/api") {
+      actionRoutes(apiComponent.actionController())
+    }
   }
 }

--- a/frontend/src/api/ClimateChangemakersAPI.ts
+++ b/frontend/src/api/ClimateChangemakersAPI.ts
@@ -37,4 +37,4 @@ export const initiateActionAPI = (email: string, streetAddress: string, city: st
             role: string;
             siteUrl: string;
         }[]
-    }>("/initiate-action", { email, streetAddress, city, state, postalCode })
+    }>("/api/initiate-action", { email, streetAddress, city, state, postalCode })


### PR DESCRIPTION
Serving static files from our Ktor instances requires that we have
separate endpoints for our static assets and api routes. This opens us
up to producing a production build with statis Js/CSS/HTML assets.

References #23
Closes #19
