### PR TITLE
Fix docker-compose port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       build: ./frontend
       image: frontend:latest
       ports:
-        - ${REACT_APP_PORT}:${REACT_APP_PORT}
+        - ${REACT_APP_PORT}:3000
     backend:
       build: ./backend
       image: backend:latest
@@ -17,7 +17,7 @@ services:
         - POSTGRES_HOSTNAME=${POSTGRES_HOSTNAME}
         - POSTGRES_PORT=${POSTGRES_PORT}
       ports:
-        - ${KOTLIN_PORT}:${KOTLIN_PORT}
+        - ${KOTLIN_PORT}:8080
     database:
       build: ./database
       image: database:latest
@@ -26,4 +26,4 @@ services:
         - POSTGRES_USER=${POSTGRES_USER}
         - POSTGRES_DB=${POSTGRES_DB} 
       ports:
-        - ${POSTGRES_PORT}:${POSTGRES_PORT}
+        - ${POSTGRES_PORT}:5432


### PR DESCRIPTION
Prior to this commit, port maps in the docker-compose file weren't
sending traffic to the internal ports that the applications
are expecting to recieve traffic on.

This commit maps ports correctly so that a local environment doesn't
have to match port numbers that the containers are expecting the find
traffic on.

Closes #29
