### PR TITLE
Add initial send-email API endpoint

### DIFF
--- a/backend/src/main/kotlin/com/climatechangemakers/act/feature/action/controller/ActionController.kt
+++ b/backend/src/main/kotlin/com/climatechangemakers/act/feature/action/controller/ActionController.kt
@@ -3,9 +3,11 @@ package com.climatechangemakers.act.feature.action.controller
 import com.climatechangemakers.act.feature.action.manager.ActionTrackerManager
 import com.climatechangemakers.act.feature.action.model.InitiateActionRequest
 import com.climatechangemakers.act.feature.action.model.InitiateActionResponse
+import com.climatechangemakers.act.feature.email.model.SendEmailRequest
 import com.climatechangemakers.act.feature.findlegislator.manager.LegislatorsManager
 import com.climatechangemakers.act.feature.findlegislator.model.GetLegislatorsByAddressRequest
 import io.ktor.application.ApplicationCall
+import io.ktor.http.HttpStatusCode.Companion.NoContent
 import io.ktor.request.receive
 import io.ktor.response.respond
 import kotlinx.coroutines.async
@@ -29,6 +31,11 @@ class ActionController @Inject constructor(
 
     launch { actionTrackerManager.trackActionInitiated(request.email) }
     call.respond(response.await())
+  }
+
+  suspend fun sendEmail(call: ApplicationCall) {
+    val request = call.receive<SendEmailRequest>()
+    call.response.status(NoContent)
   }
 }
 

--- a/backend/src/main/kotlin/com/climatechangemakers/act/feature/action/routing/ActionRoutes.kt
+++ b/backend/src/main/kotlin/com/climatechangemakers/act/feature/action/routing/ActionRoutes.kt
@@ -8,7 +8,6 @@ import io.ktor.routing.post
 
 fun Route.actionRoutes(controller: ActionController) {
 
-  post("/initiate-action") {
-    controller.initiateAction(call)
-  }
+  post("/initiate-action") { controller.initiateAction(call) }
+  post("/send-email") { controller.sendEmail(call) }
 }

--- a/backend/src/main/kotlin/com/climatechangemakers/act/feature/email/model/SendEmailRequest.kt
+++ b/backend/src/main/kotlin/com/climatechangemakers/act/feature/email/model/SendEmailRequest.kt
@@ -1,0 +1,9 @@
+package com.climatechangemakers.act.feature.email.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable class SendEmailRequest(
+  val relatedIssueId: Int,
+  val emailBody: String,
+  val contactedBioguideIds: List<String>,
+)


### PR DESCRIPTION
This commit adds mocked out support for sending an email.
Going forward, this endpoint may change slightly depending on
what information Action Network requires.

References #56.
