### PR TITLE
Remove LCV score existence check

### DIFF
--- a/backend/src/main/kotlin/com/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManager.kt
+++ b/backend/src/main/kotlin/com/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManager.kt
@@ -37,7 +37,7 @@ class LegislatorsManager @Inject constructor(
         geocodioLegislator.toDomainLegislator(
           state = request.state,
           districtNumber = congressionalDistrict.districtNumber,
-          lcvScores = lcvScores.await().also { check(it.isNotEmpty()) },
+          lcvScores = lcvScores.await(),
           districtPhoneNumber = districtPhoneNumber.await(),
         )
       }

--- a/backend/src/test/kotlin/com/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManagerTest.kt
+++ b/backend/src/test/kotlin/com/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManagerTest.kt
@@ -141,26 +141,4 @@ class LegislatorsManagerTest {
       actual = response
     )
   }
-
-  @Test fun `getLegislators throws IllegalStateException with wrong LCV scores`() = suspendTest {
-    val request = GetLegislatorsByAddressRequest(
-      streetAddress = "10 Beech Place",
-      city = "West Deptford",
-      state = "NJ",
-      postalCode = "08096",
-    )
-
-    val manager = LegislatorsManager(
-      geocodioService = fakeGeocodioService,
-      lcvScoreManager = object : LcvScoreManager {
-        override suspend fun getLifetimeScore(bioguideId: String): LcvScore? = null
-        override suspend fun getYearlyScores(bioguideId: String): List<LcvScore> = emptyList()
-      },
-      fakeDistrictOfficerManager,
-    )
-
-    assertFailsWith<IllegalStateException> {
-      manager.getLegislators(request)
-    }
-  }
 }

--- a/backend/src/test/kotlin/com/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManagerTest.kt
+++ b/backend/src/test/kotlin/com/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManagerTest.kt
@@ -22,7 +22,6 @@ import com.climatechangemakers.act.feature.lcvscore.model.LcvScore
 import com.climatechangemakers.act.feature.lcvscore.model.LcvScoreType
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 class LegislatorsManagerTest {
 


### PR DESCRIPTION
It's possible that a member of congress doesn't have a LCV score. This
could be because the MoC is new and hasn't voted on any climate
legislation yet.
