### PR TITLE
Include initial serialization schema for CWC

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,6 +1,4 @@
-import org.jetbrains.kotlin.kapt3.base.Kapt.kapt
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import org.jetbrains.kotlin.cli.jvm.compiler.findMainClass
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val ktor_version: String by project
@@ -69,6 +67,7 @@ dependencies {
 
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2")
+    implementation("io.github.pdvrieze.xmlutil:serialization-jvm:0.83.0")
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0")
     implementation("io.ktor:ktor-serialization:$ktor_version")
 

--- a/backend/src/main/kotlin/org/climatechangemakers/act/common/model/RepresentedArea.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/common/model/RepresentedArea.kt
@@ -4,7 +4,10 @@ import kotlinx.serialization.Serializable
 import org.climatechangemakers.act.common.serializers.StringEnum
 import org.climatechangemakers.act.common.serializers.StringEnumSerializer
 
-@Serializable(with = StateSerializer::class) enum class State(override val value: String) : StringEnum {
+/**
+ * An area which has at least one representatives present in Congress.
+ */
+@Serializable(with = StateSerializer::class) enum class RepresentedArea(override val value: String) : StringEnum {
   Alaska("AK"),
   Alabama("AL"),
   AmericanSamoa("AS"),
@@ -65,4 +68,4 @@ import org.climatechangemakers.act.common.serializers.StringEnumSerializer
   override fun toString() = value
 }
 
-object StateSerializer : StringEnumSerializer<State>(State.values())
+object StateSerializer : StringEnumSerializer<RepresentedArea>(RepresentedArea.values())

--- a/backend/src/main/kotlin/org/climatechangemakers/act/common/model/RepresentedArea.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/common/model/RepresentedArea.kt
@@ -7,7 +7,7 @@ import org.climatechangemakers.act.common.serializers.StringEnumSerializer
 /**
  * An area which has at least one representatives present in Congress.
  */
-@Serializable(with = StateSerializer::class) enum class RepresentedArea(override val value: String) : StringEnum {
+@Serializable(with = RepresentedAreaSerializer::class) enum class RepresentedArea(override val value: String) : StringEnum {
   Alaska("AK"),
   Alabama("AL"),
   AmericanSamoa("AS"),
@@ -68,4 +68,4 @@ import org.climatechangemakers.act.common.serializers.StringEnumSerializer
   override fun toString() = value
 }
 
-object StateSerializer : StringEnumSerializer<RepresentedArea>(RepresentedArea.values())
+object RepresentedAreaSerializer : StringEnumSerializer<RepresentedArea>(RepresentedArea.values())

--- a/backend/src/main/kotlin/org/climatechangemakers/act/common/model/State.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/common/model/State.kt
@@ -5,14 +5,15 @@ import org.climatechangemakers.act.common.serializers.StringEnum
 import org.climatechangemakers.act.common.serializers.StringEnumSerializer
 
 @Serializable(with = StateSerializer::class) enum class State(override val value: String) : StringEnum {
-  Alabama("AL"),
   Alaska("AK"),
+  Alabama("AL"),
   AmericanSamoa("AS"),
   Arizona("AZ"),
   Arkansas("AR"),
   California("CA"),
   Colorado("CO"),
   Connecticut("CT"),
+  DistrictOfColumbia("DC"),
   Delaware("DE"),
   Florida("FL"),
   Georgia("GA"),
@@ -41,6 +42,7 @@ import org.climatechangemakers.act.common.serializers.StringEnumSerializer
   NewYork("NY"),
   NorthCarolina("NC"),
   NorthDakota("ND"),
+  NorthernMarianaIslands("MP"),
   Ohio("OH"),
   Oklahoma("OK"),
   Oregon("OR"),

--- a/backend/src/main/kotlin/org/climatechangemakers/act/common/model/State.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/common/model/State.kt
@@ -1,0 +1,66 @@
+package org.climatechangemakers.act.common.model
+
+import kotlinx.serialization.Serializable
+import org.climatechangemakers.act.common.serializers.StringEnum
+import org.climatechangemakers.act.common.serializers.StringEnumSerializer
+
+@Serializable(with = StateSerializer::class) enum class State(override val value: String) : StringEnum {
+  Alabama("AL"),
+  Alaska("AK"),
+  AmericanSamoa("AS"),
+  Arizona("AZ"),
+  Arkansas("AR"),
+  California("CA"),
+  Colorado("CO"),
+  Connecticut("CT"),
+  Delaware("DE"),
+  Florida("FL"),
+  Georgia("GA"),
+  Guam("GU"),
+  Hawaii("HI"),
+  Idaho("ID"),
+  Illinois("IL"),
+  Indiana("IN"),
+  Iowa("IA"),
+  Kansas("KS"),
+  Kentucky("KY"),
+  Louisiana("LA"),
+  Maine("ME"),
+  Maryland("MD"),
+  Massachusetts("MA"),
+  Michigan("MI"),
+  Minnesota("MN"),
+  Mississippi("MS"),
+  Missouri("MO"),
+  Montana("MT"),
+  Nebraska("NE"),
+  Nevada("NV"),
+  NewHampshire("NH"),
+  NewJersey("NJ"),
+  NewMexico("NM"),
+  NewYork("NY"),
+  NorthCarolina("NC"),
+  NorthDakota("ND"),
+  Ohio("OH"),
+  Oklahoma("OK"),
+  Oregon("OR"),
+  Pennsylvania("PA"),
+  PuertoRico("PR"),
+  RhodeIsland("RI"),
+  SouthCarolina("SC"),
+  SouthDakota("SD"),
+  Tennessee("TN"),
+  Texas("TX"),
+  Utah("UT"),
+  VirginIslands("VI"),
+  Vermont("VT"),
+  Virginia("VA"),
+  Washington("WA"),
+  WestVirginia("WV"),
+  Wisconsin("WI"),
+  Wyoming("WY");
+
+  override fun toString() = value
+}
+
+object StateSerializer : StringEnumSerializer<State>(State.values())

--- a/backend/src/main/kotlin/org/climatechangemakers/act/common/serializers/DateSerializer.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/common/serializers/DateSerializer.kt
@@ -1,0 +1,17 @@
+package org.climatechangemakers.act.common.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.text.SimpleDateFormat
+import java.util.Date
+
+object DateSerializer : KSerializer<Date> {
+  override val descriptor = PrimitiveSerialDescriptor("Date", PrimitiveKind.STRING)
+  override fun serialize(encoder: Encoder, value: Date) = encoder.encodeString(value.toEightCharFormat())
+  override fun deserialize(decoder: Decoder): Date = TODO()
+}
+
+fun Date.toEightCharFormat(): String = SimpleDateFormat("YYYYMMDD").format(this)

--- a/backend/src/main/kotlin/org/climatechangemakers/act/common/serializers/StringEnumSerializer.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/common/serializers/StringEnumSerializer.kt
@@ -1,0 +1,22 @@
+package org.climatechangemakers.act.common.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+interface StringEnum {
+  val value: String
+}
+
+abstract class StringEnumSerializer<T>(
+  private val enumValues: Array<out T>,
+) : KSerializer<T> where T : StringEnum, T : Enum<T> {
+
+  override val descriptor get() = PrimitiveSerialDescriptor("StringEnumSerializer", PrimitiveKind.STRING)
+  override fun serialize(encoder: Encoder, value: T) = encoder.encodeString(value.value)
+  override fun deserialize(decoder: Decoder): T = decoder.decodeString().let { value ->
+    enumValues.first { it.value == value }
+  }
+}

--- a/backend/src/main/kotlin/org/climatechangemakers/act/common/serializers/UUIDSerializer.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/common/serializers/UUIDSerializer.kt
@@ -1,0 +1,16 @@
+package org.climatechangemakers.act.common.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.util.UUID
+
+object UUIDSerializer : KSerializer<UUID> {
+  override val descriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+  override fun serialize(encoder: Encoder, value: UUID) = encoder.encodeString(value.toAlphaNumericString())
+  override fun deserialize(decoder: Decoder): UUID = TODO()
+}
+
+fun UUID.toAlphaNumericString(): String = toString().filter { it != '-' }

--- a/backend/src/main/kotlin/org/climatechangemakers/act/common/serializers/YesNoBooleanSerializer.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/common/serializers/YesNoBooleanSerializer.kt
@@ -1,0 +1,22 @@
+package org.climatechangemakers.act.common.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object YesNoBooleanSerializer : KSerializer<Boolean> {
+
+  override val descriptor = PrimitiveSerialDescriptor("Y/N", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: Boolean) = encoder.encodeString(
+    if (value) "Y" else "N"
+  )
+
+  override fun deserialize(decoder: Decoder): Boolean = when (val code = decoder.decodeString()) {
+    "Y" -> true
+    "N" -> false
+    else -> error("Got $code but expected either Y or N")
+  }
+}

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/model/InitiateActionRequest.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/model/InitiateActionRequest.kt
@@ -1,13 +1,13 @@
 package org.climatechangemakers.act.feature.action.model
 
 import kotlinx.serialization.Serializable
-import org.climatechangemakers.act.common.model.State
+import org.climatechangemakers.act.common.model.RepresentedArea
 
 @Serializable class InitiateActionRequest(
   val email: String,
   val streetAddress: String,
   val city: String,
-  val state: State,
+  val state: RepresentedArea,
   val postalCode: String,
   val consentToTrackImpact: Boolean,
   val desiresInformationalEmails: Boolean,

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/model/InitiateActionRequest.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/model/InitiateActionRequest.kt
@@ -1,12 +1,13 @@
 package org.climatechangemakers.act.feature.action.model
 
 import kotlinx.serialization.Serializable
+import org.climatechangemakers.act.common.model.State
 
 @Serializable class InitiateActionRequest(
   val email: String,
   val streetAddress: String,
   val city: String,
-  val state: String,
+  val state: State,
   val postalCode: String,
   val consentToTrackImpact: Boolean,
   val desiresInformationalEmails: Boolean,

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Bill.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Bill.kt
@@ -1,0 +1,29 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlElement
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import org.climatechangemakers.act.common.serializers.StringEnum
+import org.climatechangemakers.act.common.serializers.StringEnumSerializer
+
+@Serializable class Bill(
+  @XmlElement(true) @XmlSerialName("BillCongress", "", "") val congressNumber: Int,
+  @XmlElement(true) @XmlSerialName("BillTypeAbbreviation", "", "") val billType: BillType,
+  @XmlElement(true) @XmlSerialName("BillNumber", "", "") val billNumber: Int,
+)
+
+@Serializable(with = BillTypeSerializer::class) enum class BillType(override val value: String) : StringEnum {
+  HouseAmendment("H.Amdt."),
+  HouseConcurrentResolution("H.Con.Res."),
+  HouseJointResolution("H.J.Res."),
+  HouseBill("H.R."),
+  HouseResolution("H.Res."),
+
+  SenateAmendment("S.Amdt."),
+  SenateConcurrentResolution("S.Con.Res."),
+  SenateJointResolution("S.J.Res."),
+  SenateBill("S."),
+  SenateResolution("S.Res."),
+}
+
+private object BillTypeSerializer : StringEnumSerializer<BillType>(BillType.values())

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/CommunicateWithCogressRequest.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/CommunicateWithCogressRequest.kt
@@ -1,0 +1,15 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlElement
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+
+@Serializable
+@XmlSerialName("CWC", namespace = "", prefix = "")
+class CommunicateWithCogressRequest(
+  @XmlElement(true) @XmlSerialName("CWCVersion", "", "") val version: Double,
+  @XmlElement(true) val delivery: Delivery,
+  @XmlElement(true) val recipient: Recipient,
+  @XmlElement(true) val constituent: Constituent,
+  @XmlElement(true) val message: Message,
+)

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Constituent.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Constituent.kt
@@ -1,0 +1,20 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlElement
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import org.climatechangemakers.act.common.model.State
+
+@Serializable class Constituent(
+  @XmlElement(true) @XmlSerialName("Prefix", "", "") val prefix: Prefix,
+  @XmlElement(true) @XmlSerialName("FirstName", "", "") val firstName: String,
+  @XmlElement(true) @XmlSerialName("MiddleName", "", "") val middleName: String?,
+  @XmlElement(true) @XmlSerialName("LastName", "", "") val lastName: String,
+  @XmlElement(true) @XmlSerialName("Suffix", "", "") val suffix: String?,
+  @XmlElement(true) @XmlSerialName("Title", "", "") val title: String?,
+  @XmlElement(true) @XmlSerialName("Address1", "", "") val address: String,
+  @XmlElement(true) @XmlSerialName("City", "", "") val city: String,
+  @XmlElement(true) @XmlSerialName("StateAbbreviation", "", "") val state: State,
+  @XmlElement(true) @XmlSerialName("Zip", "", "") val postalCode: String,
+  @XmlElement(true) @XmlSerialName("Email", "", "") val email: String,
+)

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Constituent.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Constituent.kt
@@ -3,7 +3,7 @@ package org.climatechangemakers.act.feature.communicatewithcongress.model
 import kotlinx.serialization.Serializable
 import nl.adaptivity.xmlutil.serialization.XmlElement
 import nl.adaptivity.xmlutil.serialization.XmlSerialName
-import org.climatechangemakers.act.common.model.State
+import org.climatechangemakers.act.common.model.RepresentedArea
 
 @Serializable class Constituent(
   @XmlElement(true) @XmlSerialName("Prefix", "", "") val prefix: Prefix,
@@ -14,7 +14,7 @@ import org.climatechangemakers.act.common.model.State
   @XmlElement(true) @XmlSerialName("Title", "", "") val title: String?,
   @XmlElement(true) @XmlSerialName("Address1", "", "") val address: String,
   @XmlElement(true) @XmlSerialName("City", "", "") val city: String,
-  @XmlElement(true) @XmlSerialName("StateAbbreviation", "", "") val state: State,
+  @XmlElement(true) @XmlSerialName("StateAbbreviation", "", "") val state: RepresentedArea,
   @XmlElement(true) @XmlSerialName("Zip", "", "") val postalCode: String,
   @XmlElement(true) @XmlSerialName("Email", "", "") val email: String,
 )

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Delivery.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Delivery.kt
@@ -1,0 +1,55 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlElement
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import org.climatechangemakers.act.common.serializers.DateSerializer
+import org.climatechangemakers.act.common.serializers.UUIDSerializer
+import java.util.Date
+import java.util.UUID
+
+@Serializable class Delivery(
+
+  @XmlElement(true)
+  @XmlSerialName("CampaignId", "", "")
+  val campaignId: String,
+
+  @XmlElement(true)
+  @XmlSerialName("DeliveryId", "", "")
+  @Serializable(with = UUIDSerializer::class)
+  val deliveryId: UUID = UUID.randomUUID(),
+
+  @XmlElement(true)
+  @XmlSerialName("DeliveryDate", "", "")
+  @Serializable(with = DateSerializer::class)
+  val deliveryDate: Date = Date(),
+) {
+
+  // Below are static values which don't need to be parametarized.
+
+  @XmlElement(true)
+  @XmlSerialName("DeliveryAgent", "", "")
+  val deliveryAgent = "Climate Changemakers"
+
+  @XmlElement(true)
+  @XmlSerialName("DeliveryAgentAckEmailAddress", "", "")
+  val deliveryAgentAckEmailAddress = "info@climatechangemakers.org"
+
+  @XmlElement(true)
+  val contact = DeliveryAgentContact(
+    "Eliza Nemser",
+    "eliza@climatechangemakers.org",
+    "555-555-5555", // TODO(kcianfarini) get contact information
+  )
+
+  @XmlElement(true)
+  @XmlSerialName("Organization", "", "")
+  val organization = "Climate Changemakers"
+
+  @XmlElement(true)
+  @XmlSerialName("OrganizationAbout", "", "")
+  val organizationAbout = """
+    Climate Changemakers is a non-partisan climate crisis mitigation advocacy group dedicated to 
+    enacting climate policy. 
+  """.trimIndent()
+}

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/DeliveryAgentContact.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/DeliveryAgentContact.kt
@@ -1,0 +1,11 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlElement
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+
+@Serializable class DeliveryAgentContact(
+  @XmlElement(true) @XmlSerialName("DeliveryAgentContactName", "", "") val contactName: String,
+  @XmlElement(true) @XmlSerialName("DeliveryAgentContactEmail", "", "") val contactEmail: String,
+  @XmlElement(true) @XmlSerialName("DeliveryAgentContactPhone", "", "") val contactPhoneNumber: String,
+)

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Message.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Message.kt
@@ -1,0 +1,22 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlChildrenName
+import nl.adaptivity.xmlutil.serialization.XmlElement
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+
+@Serializable class Message(
+  @XmlElement(true) @XmlSerialName("Subject", "", "") val subject: String,
+
+  @XmlElement(true)
+  @XmlSerialName("LibraryOfCongressTopics", "", "")
+  @XmlChildrenName("LibraryOfCongressTopic", "", "")
+  val topics: List<Topic>,
+
+  @XmlElement(true)
+  @XmlSerialName("Bills", "", "")
+  @XmlChildrenName("Bill", "", "")
+  val bills: List<Bill>,
+
+  @XmlElement(true) @XmlSerialName("ConstituentMessage", "", "") val body: String,
+)

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Prefix.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Prefix.kt
@@ -1,0 +1,15 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.Serializable
+import org.climatechangemakers.act.common.serializers.StringEnum
+import org.climatechangemakers.act.common.serializers.StringEnumSerializer
+
+@Serializable(with = PrefixSerializer::class) enum class Prefix(override val value: String) : StringEnum {
+  Mr("Mr."),
+  Mrs("Mrs."),
+  Miss("Miss"),
+  Ms("Ms."),
+  Dr("Dr.")
+}
+
+private object PrefixSerializer : StringEnumSerializer<Prefix>(Prefix.values())

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Recipient.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Recipient.kt
@@ -1,0 +1,20 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlElement
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import org.climatechangemakers.act.common.serializers.YesNoBooleanSerializer
+
+@Serializable class Recipient(
+  @XmlElement(true) @XmlSerialName("MemberOffice", "", "") val officeCode: String,
+
+  @XmlElement(true)
+  @XmlSerialName("IsResponseRequested", "", "")
+  @Serializable(with = YesNoBooleanSerializer::class)
+  val responseRequested: Boolean = false,
+
+  @XmlElement(true)
+  @XmlSerialName("NewsletterOptIn", "", "")
+  @Serializable(with = YesNoBooleanSerializer::class)
+  val optInToNewsletter: Boolean = false,
+)

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Topic.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/Topic.kt
@@ -1,0 +1,42 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.Serializable
+import org.climatechangemakers.act.common.serializers.StringEnum
+import org.climatechangemakers.act.common.serializers.StringEnumSerializer
+
+@Serializable(with = TopicSerializer::class) enum class Topic(override val value: String) : StringEnum {
+  AgricultureAndFood("Agriculture and Food"),
+  Animals("Animals"),
+  ArmedForcesAndNationalSecurity("Armed Forces and National Security"),
+  ArtsCultureReligion("Arts, Culture, Religion"),
+  CivilRightsMinorityIssues("Civil Rights and Liberties, Minority Issues"),
+  Commerce("Commerce"),
+  Congress("Congress"),
+  CrimeAndLawEnforcement("Crime and Law Enforcement"),
+  EconomicsAndPublicFinance("Economics and Public Finance"),
+  Education("Education"),
+  EmergencyManagement("Emergency Management"),
+  Energy("Energy"),
+  EnvironmentalProtection("Environmental Protection"),
+  Families("Families"),
+  FinanceAndFinancialSector("Finance and Financial Sector"),
+  ForeignTradeAndInternationalFinance("Foreign Trade and International Finance"),
+  GovernmentOperationsAndPolitics("Government Operations and Politics"),
+  Health("Health"),
+  HousingAndCommunityDevelopment("Housing and Community Development"),
+  Immigration("Immigration"),
+  InternationalAffairs("International Affairs"),
+  LaborAndEmployment("Labor and Employment"),
+  Law("Law"),
+  NativeAmericans("Native Americans"),
+  PublicLandsAndNaturalResources("Public Lands and Natural Resources"),
+  ScienceTechnologyCommunications("Science, Technology, Communications"),
+  SocialSciencesAndHistory("Social Sciences and History"),
+  SocialWelfare("Social Welfare"),
+  SportsAndRecreation("Sports and Recreation"),
+  Taxation("Taxation"),
+  TransportationAndPublicWorks("Transportation and Public Works"),
+  WaterResourcesDevelopment("Water Resources Development"),
+}
+
+private object TopicSerializer : StringEnumSerializer<Topic>(Topic.values())

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManager.kt
@@ -12,6 +12,7 @@ import org.climatechangemakers.act.feature.lcvscore.model.LcvScore
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import org.climatechangemakers.act.common.model.State
 import javax.inject.Inject
 
 class LegislatorsManager @Inject constructor(
@@ -59,7 +60,7 @@ private val GetLegislatorsByAddressRequest.queryString: String get() = "$streetA
 private val GeocodioLegislator.fullName get() = "${bio.firstName} ${bio.lastName}"
 
 private fun GeocodioLegislator.toDomainLegislator(
-  state: String,
+  state: State,
   districtNumber: Int,
   districtPhoneNumber: String?,
   lcvScores: List<LcvScore>,

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManager.kt
@@ -12,7 +12,7 @@ import org.climatechangemakers.act.feature.lcvscore.model.LcvScore
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import org.climatechangemakers.act.common.model.State
+import org.climatechangemakers.act.common.model.RepresentedArea
 import javax.inject.Inject
 
 class LegislatorsManager @Inject constructor(
@@ -60,7 +60,7 @@ private val GetLegislatorsByAddressRequest.queryString: String get() = "$streetA
 private val GeocodioLegislator.fullName get() = "${bio.firstName} ${bio.lastName}"
 
 private fun GeocodioLegislator.toDomainLegislator(
-  state: State,
+  state: RepresentedArea,
   districtNumber: Int,
   districtPhoneNumber: String?,
   lcvScores: List<LcvScore>,

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GetLegislatorsByAddressRequest.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GetLegislatorsByAddressRequest.kt
@@ -1,10 +1,11 @@
 package org.climatechangemakers.act.feature.findlegislator.model
 
 import kotlinx.serialization.Serializable
+import org.climatechangemakers.act.common.model.State
 
 @Serializable class GetLegislatorsByAddressRequest(
   val streetAddress: String,
   val city: String,
-  val state: String,
+  val state: State,
   val postalCode: String,
 )

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GetLegislatorsByAddressRequest.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GetLegislatorsByAddressRequest.kt
@@ -1,11 +1,11 @@
 package org.climatechangemakers.act.feature.findlegislator.model
 
 import kotlinx.serialization.Serializable
-import org.climatechangemakers.act.common.model.State
+import org.climatechangemakers.act.common.model.RepresentedArea
 
 @Serializable class GetLegislatorsByAddressRequest(
   val streetAddress: String,
   val city: String,
-  val state: State,
+  val state: RepresentedArea,
   val postalCode: String,
 )

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/LegislatorArea.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/LegislatorArea.kt
@@ -1,9 +1,9 @@
 package org.climatechangemakers.act.feature.findlegislator.model
 
 import kotlinx.serialization.Serializable
-import org.climatechangemakers.act.common.model.State
+import org.climatechangemakers.act.common.model.RepresentedArea
 
 @Serializable data class LegislatorArea(
-  val state: State,
+  val state: RepresentedArea,
   val districtNumber: Int?,
 )

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/LegislatorArea.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/LegislatorArea.kt
@@ -1,8 +1,9 @@
 package org.climatechangemakers.act.feature.findlegislator.model
 
 import kotlinx.serialization.Serializable
+import org.climatechangemakers.act.common.model.State
 
 @Serializable data class LegislatorArea(
-  val state: String,
+  val state: State,
   val districtNumber: Int?,
 )

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/BillSerializationTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/BillSerializationTest.kt
@@ -1,0 +1,28 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.encodeToString
+import nl.adaptivity.xmlutil.serialization.XML
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class BillSerializationTest {
+
+  private val xml = XML {
+    indentString = " "
+    indent = 2
+  }
+
+  @Test fun `Bill serializes correctly`() {
+    val bill = Bill(117, BillType.HouseResolution, 1234)
+    assertEquals(
+      """
+        |<Bill>
+        |  <BillCongress>117</BillCongress>
+        |  <BillTypeAbbreviation>H.Res.</BillTypeAbbreviation>
+        |  <BillNumber>1234</BillNumber>
+        |</Bill>
+      """.trimMargin(),
+      xml.encodeToString(bill)
+    )
+  }
+}

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/CommunicateWithCongressSerializationTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/CommunicateWithCongressSerializationTest.kt
@@ -3,7 +3,7 @@ package org.climatechangemakers.act.feature.communicatewithcongress.model
 import kotlinx.serialization.encodeToString
 import nl.adaptivity.xmlutil.XmlDeclMode
 import nl.adaptivity.xmlutil.serialization.XML
-import org.climatechangemakers.act.common.model.State
+import org.climatechangemakers.act.common.model.RepresentedArea
 import org.junit.Test
 import java.util.Calendar
 import java.util.Calendar.JANUARY
@@ -40,7 +40,7 @@ class CommunicateWithCongressSerializationTest {
         title = null,
         address = "123 Main Street",
         city = "My City",
-        state = State.Virginia,
+        state = RepresentedArea.Virginia,
         postalCode = "12345",
         email = "myemail@email.com",
       ),

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/CommunicateWithCongressSerializationTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/CommunicateWithCongressSerializationTest.kt
@@ -1,0 +1,111 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.encodeToString
+import nl.adaptivity.xmlutil.XmlDeclMode
+import nl.adaptivity.xmlutil.serialization.XML
+import org.climatechangemakers.act.common.model.State
+import org.junit.Test
+import java.util.Calendar
+import java.util.Calendar.JANUARY
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class CommunicateWithCongressSerializationTest {
+
+  private val xml = XML {
+    xmlDeclMode = XmlDeclMode.Charset
+    indentString = " "
+    indent = 2
+  }
+
+  @Test fun `sample object structure serializes correctly`() {
+    val request = CommunicateWithCogressRequest(
+      version = 2.0,
+      delivery = Delivery(
+        deliveryId = UUID.fromString("19739ece-434e-488a-9857-a338a918a798"),
+        deliveryDate = Calendar.getInstance().apply {
+          set(Calendar.YEAR, 2020)
+          set(Calendar.MONTH, JANUARY)
+          set(Calendar.DAY_OF_MONTH, 1)
+        }.time,
+        campaignId = "This is a campaign ID",
+      ),
+      recipient = Recipient(officeCode = "SWY01"),
+      constituent = Constituent(
+        prefix = Prefix.Mr,
+        firstName = "Kevin",
+        middleName = null,
+        lastName = "McDoodle",
+        suffix = null,
+        title = null,
+        address = "123 Main Street",
+        city = "My City",
+        state = State.Virginia,
+        postalCode = "12345",
+        email = "myemail@email.com",
+      ),
+      message = Message(
+        subject = "This is a subject",
+        topics = listOf(Topic.Energy, Topic.EnvironmentalProtection),
+        bills = listOf(
+          Bill(117, BillType.HouseBill, 2519)
+        ),
+        body = "foo",
+      ),
+    )
+
+    assertEquals(
+      """
+        |<?xml version="1.0" encoding="UTF-8"?>
+        |<CWC>
+        |  <CWCVersion>2.0</CWCVersion>
+        |  <Delivery>
+        |    <CampaignId>This is a campaign ID</CampaignId>
+        |    <DeliveryId>19739ece434e488a9857a338a918a798</DeliveryId>
+        |    <DeliveryDate>20200101</DeliveryDate>
+        |    <DeliveryAgent>Climate Changemakers</DeliveryAgent>
+        |    <DeliveryAgentAckEmailAddress>info@climatechangemakers.org</DeliveryAgentAckEmailAddress>
+        |    <DeliveryAgentContact>
+        |      <DeliveryAgentContactName>Eliza Nemser</DeliveryAgentContactName>
+        |      <DeliveryAgentContactEmail>eliza@climatechangemakers.org</DeliveryAgentContactEmail>
+        |      <DeliveryAgentContactPhone>555-555-5555</DeliveryAgentContactPhone>
+        |    </DeliveryAgentContact>
+        |    <Organization>Climate Changemakers</Organization>
+        |    <OrganizationAbout>Climate Changemakers is a non-partisan climate crisis mitigation advocacy group dedicated to ${'\n'}enacting climate policy. </OrganizationAbout>
+        |  </Delivery>
+        |  <Recipient>
+        |    <MemberOffice>SWY01</MemberOffice>
+        |    <IsResponseRequested>N</IsResponseRequested>
+        |    <NewsletterOptIn>N</NewsletterOptIn>
+        |  </Recipient>
+        |  <Constituent>
+        |    <Prefix>Mr.</Prefix>
+        |    <FirstName>Kevin</FirstName>
+        |    <LastName>McDoodle</LastName>
+        |    <Address1>123 Main Street</Address1>
+        |    <City>My City</City>
+        |    <StateAbbreviation>VA</StateAbbreviation>
+        |    <Zip>12345</Zip>
+        |    <Email>myemail@email.com</Email>
+        |  </Constituent>
+        |  <Message>
+        |    <Subject>This is a subject</Subject>
+        |    <LibraryOfCongressTopics>
+        |      <LibraryOfCongressTopic>Energy</LibraryOfCongressTopic>
+        |      <LibraryOfCongressTopic>Environmental Protection</LibraryOfCongressTopic>
+        |    </LibraryOfCongressTopics>
+        |    <Bills>
+        |      <Bill>
+        |        <BillCongress>117</BillCongress>
+        |        <BillTypeAbbreviation>H.R.</BillTypeAbbreviation>
+        |        <BillNumber>2519</BillNumber>
+        |      </Bill>
+        |    </Bills>
+        |    <ConstituentMessage>foo</ConstituentMessage>
+        |  </Message>
+        |</CWC>
+      """.trimMargin(),
+      xml.encodeToString(request),
+    )
+  }
+}

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/ConstituentSerializationTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/ConstituentSerializationTest.kt
@@ -1,0 +1,50 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.encodeToString
+import nl.adaptivity.xmlutil.serialization.XML
+import org.climatechangemakers.act.common.model.State
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class ConstituentSerializationTest {
+
+  private val xml = XML {
+    indentString = " "
+    indent = 2
+  }
+
+  @Test fun `Constituent serializes correctly`() {
+    val constituent = Constituent(
+      prefix = Prefix.Dr,
+      firstName = "Kevin",
+      middleName = "Bob",
+      lastName = "McDoodle",
+      suffix = "Jr.",
+      title = "Climate Change Advocate",
+      address = "123 Main Street",
+      city = "City",
+      state = State.WestVirginia,
+      postalCode = "12345",
+      email = "fake@fake.org",
+    )
+
+    assertEquals(
+      """
+        |<Constituent>
+        |  <Prefix>Dr.</Prefix>
+        |  <FirstName>Kevin</FirstName>
+        |  <MiddleName>Bob</MiddleName>
+        |  <LastName>McDoodle</LastName>
+        |  <Suffix>Jr.</Suffix>
+        |  <Title>Climate Change Advocate</Title>
+        |  <Address1>123 Main Street</Address1>
+        |  <City>City</City>
+        |  <StateAbbreviation>WV</StateAbbreviation>
+        |  <Zip>12345</Zip>
+        |  <Email>fake@fake.org</Email>
+        |</Constituent>
+      """.trimMargin(),
+      xml.encodeToString(constituent),
+    )
+  }
+}

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/ConstituentSerializationTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/ConstituentSerializationTest.kt
@@ -2,7 +2,7 @@ package org.climatechangemakers.act.feature.communicatewithcongress.model
 
 import kotlinx.serialization.encodeToString
 import nl.adaptivity.xmlutil.serialization.XML
-import org.climatechangemakers.act.common.model.State
+import org.climatechangemakers.act.common.model.RepresentedArea
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -23,7 +23,7 @@ class ConstituentSerializationTest {
       title = "Climate Change Advocate",
       address = "123 Main Street",
       city = "City",
-      state = State.WestVirginia,
+      state = RepresentedArea.WestVirginia,
       postalCode = "12345",
       email = "fake@fake.org",
     )

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/DeliverySerializationTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/DeliverySerializationTest.kt
@@ -1,0 +1,47 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.encodeToString
+import nl.adaptivity.xmlutil.serialization.XML
+import org.junit.Test
+import java.util.Calendar
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class DeliverySerializationTest {
+
+  private val xml = XML {
+    indentString = " "
+    indent = 2
+  }
+
+  @Test fun `Delivery serializes correctly`() {
+    val delivery = Delivery(
+      deliveryId = UUID.fromString("19739ece-434e-488a-9857-a338a918a798"),
+      deliveryDate = Calendar.getInstance().apply {
+        set(Calendar.YEAR, 2020)
+        set(Calendar.MONTH, Calendar.JANUARY)
+        set(Calendar.DAY_OF_MONTH, 1)
+      }.time,
+      campaignId = "xyz",
+    )
+    assertEquals(
+      """
+        |<Delivery>
+        |  <CampaignId>xyz</CampaignId>
+        |  <DeliveryId>19739ece434e488a9857a338a918a798</DeliveryId>
+        |  <DeliveryDate>20200101</DeliveryDate>
+        |  <DeliveryAgent>Climate Changemakers</DeliveryAgent>
+        |  <DeliveryAgentAckEmailAddress>info@climatechangemakers.org</DeliveryAgentAckEmailAddress>
+        |  <DeliveryAgentContact>
+        |    <DeliveryAgentContactName>Eliza Nemser</DeliveryAgentContactName>
+        |    <DeliveryAgentContactEmail>eliza@climatechangemakers.org</DeliveryAgentContactEmail>
+        |    <DeliveryAgentContactPhone>555-555-5555</DeliveryAgentContactPhone>
+        |  </DeliveryAgentContact>
+        |  <Organization>Climate Changemakers</Organization>
+        |  <OrganizationAbout>Climate Changemakers is a non-partisan climate crisis mitigation advocacy group dedicated to ${'\n'}enacting climate policy. </OrganizationAbout>
+        |</Delivery>
+      """.trimMargin(),
+      xml.encodeToString(delivery),
+    )
+  }
+}

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/MessageSerializationTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/MessageSerializationTest.kt
@@ -1,0 +1,76 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import kotlinx.serialization.encodeToString
+import nl.adaptivity.xmlutil.serialization.XML
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class MessageSerializationTest {
+
+  private val xml = XML {
+    indentString = " "
+    indent = 2
+  }
+
+  @Test fun `message serializes correctly`() {
+    val message = Message(
+      subject = "America needs to keep it in the ground",
+      topics = Topic.values().toList(),
+      body = "Fucking do something about climate change, congress.",
+      bills = listOf(
+        Bill(117, BillType.SenateBill, 1234)
+      ),
+    )
+
+    assertEquals(
+      """
+        |<Message>
+        |  <Subject>America needs to keep it in the ground</Subject>
+        |  <LibraryOfCongressTopics>
+        |    <LibraryOfCongressTopic>Agriculture and Food</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Animals</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Armed Forces and National Security</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Arts, Culture, Religion</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Civil Rights and Liberties, Minority Issues</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Commerce</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Congress</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Crime and Law Enforcement</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Economics and Public Finance</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Education</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Emergency Management</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Energy</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Environmental Protection</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Families</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Finance and Financial Sector</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Foreign Trade and International Finance</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Government Operations and Politics</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Health</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Housing and Community Development</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Immigration</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>International Affairs</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Labor and Employment</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Law</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Native Americans</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Public Lands and Natural Resources</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Science, Technology, Communications</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Social Sciences and History</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Social Welfare</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Sports and Recreation</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Taxation</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Transportation and Public Works</LibraryOfCongressTopic>
+        |    <LibraryOfCongressTopic>Water Resources Development</LibraryOfCongressTopic>
+        |  </LibraryOfCongressTopics>
+        |  <Bills>
+        |    <Bill>
+        |      <BillCongress>117</BillCongress>
+        |      <BillTypeAbbreviation>S.</BillTypeAbbreviation>
+        |      <BillNumber>1234</BillNumber>
+        |    </Bill>
+        |  </Bills>
+        |  <ConstituentMessage>Fucking do something about climate change, congress.</ConstituentMessage>
+        |</Message>
+      """.trimMargin(),
+      xml.encodeToString(message)
+    )
+  }
+}

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/RecipientSerializationTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/RecipientSerializationTest.kt
@@ -1,0 +1,33 @@
+package org.climatechangemakers.act.feature.communicatewithcongress.model
+
+import nl.adaptivity.xmlutil.serialization.XML
+import kotlinx.serialization.encodeToString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RecipientSerializationTest {
+
+  private val xml = XML {
+    indentString = " "
+    indent = 2
+  }
+
+  @Test fun `Recipient serializes correctly`() {
+    val recipient = Recipient(
+      officeCode = "STN02",
+      responseRequested = true,
+      optInToNewsletter = false,
+    )
+
+    assertEquals(
+      """
+        |<Recipient>
+        |  <MemberOffice>STN02</MemberOffice>
+        |  <IsResponseRequested>Y</IsResponseRequested>
+        |  <NewsletterOptIn>N</NewsletterOptIn>
+        |</Recipient>
+      """.trimMargin(),
+      xml.encodeToString(recipient)
+    )
+  }
+}

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManagerTest.kt
@@ -1,6 +1,6 @@
 package org.climatechangemakers.act.feature.findlegislator.manager
 
-import org.climatechangemakers.act.common.model.State
+import org.climatechangemakers.act.common.model.RepresentedArea
 import org.climatechangemakers.act.feature.findlegislator.model.CongressionalDistrict
 import org.climatechangemakers.act.feature.findlegislator.model.Fields
 import org.climatechangemakers.act.feature.findlegislator.model.GeocodeResult
@@ -85,7 +85,7 @@ class LegislatorsManagerTest {
     val request = GetLegislatorsByAddressRequest(
       streetAddress = "10 Beech Place",
       city = "West Deptford",
-      state = State.NewJersey,
+      state = RepresentedArea.NewJersey,
       postalCode = "08096",
     )
 
@@ -101,7 +101,7 @@ class LegislatorsManagerTest {
     val request = GetLegislatorsByAddressRequest(
       streetAddress = "10 Beech Place",
       city = "West Deptford",
-      state = State.NewJersey,
+      state = RepresentedArea.NewJersey,
       postalCode = "08096",
     )
 
@@ -121,7 +121,7 @@ class LegislatorsManagerTest {
             LcvScore(10, LcvScoreType.YearlyScore(2020)),
             LcvScore(10, LcvScoreType.YearlyScore(2019)),
           ),
-          area = LegislatorArea(State.NewJersey, 4),
+          area = LegislatorArea(RepresentedArea.NewJersey, 4),
           partyAffiliation = LegislatorPoliticalParty.Democrat,
         ),
         Legislator(
@@ -136,7 +136,7 @@ class LegislatorsManagerTest {
             LcvScore(10, LcvScoreType.YearlyScore(2020)),
             LcvScore(10, LcvScoreType.YearlyScore(2019)),
           ),
-          area = LegislatorArea(State.NewJersey, null),
+          area = LegislatorArea(RepresentedArea.NewJersey, null),
           partyAffiliation = LegislatorPoliticalParty.Republican,
         ),
       ),

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/LegislatorsManagerTest.kt
@@ -1,5 +1,6 @@
 package org.climatechangemakers.act.feature.findlegislator.manager
 
+import org.climatechangemakers.act.common.model.State
 import org.climatechangemakers.act.feature.findlegislator.model.CongressionalDistrict
 import org.climatechangemakers.act.feature.findlegislator.model.Fields
 import org.climatechangemakers.act.feature.findlegislator.model.GeocodeResult
@@ -84,7 +85,7 @@ class LegislatorsManagerTest {
     val request = GetLegislatorsByAddressRequest(
       streetAddress = "10 Beech Place",
       city = "West Deptford",
-      state = "NJ",
+      state = State.NewJersey,
       postalCode = "08096",
     )
 
@@ -100,7 +101,7 @@ class LegislatorsManagerTest {
     val request = GetLegislatorsByAddressRequest(
       streetAddress = "10 Beech Place",
       city = "West Deptford",
-      state = "NJ",
+      state = State.NewJersey,
       postalCode = "08096",
     )
 
@@ -120,7 +121,7 @@ class LegislatorsManagerTest {
             LcvScore(10, LcvScoreType.YearlyScore(2020)),
             LcvScore(10, LcvScoreType.YearlyScore(2019)),
           ),
-          area = LegislatorArea("NJ", 4),
+          area = LegislatorArea(State.NewJersey, 4),
           partyAffiliation = LegislatorPoliticalParty.Democrat,
         ),
         Legislator(
@@ -135,7 +136,7 @@ class LegislatorsManagerTest {
             LcvScore(10, LcvScoreType.YearlyScore(2020)),
             LcvScore(10, LcvScoreType.YearlyScore(2019)),
           ),
-          area = LegislatorArea("NJ", null),
+          area = LegislatorArea(State.NewJersey, null),
           partyAffiliation = LegislatorPoliticalParty.Republican,
         ),
       ),


### PR DESCRIPTION
We don't currently have CWC API keys, but the documentation has allowed
me to get this far. Tests are actually written for serialization because
the CWC API ingests XML, which is a loosy goosey format.

References #36
