### PR TITLE
Add necessary fields to `SendEmailRequest`

### DIFF
--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/model/SendEmailRequest.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/model/SendEmailRequest.kt
@@ -23,5 +23,8 @@ import org.climatechangemakers.act.feature.communicatewithcongress.model.Topic
   init {
     require(contactedBioguideIds.isNotEmpty())
     require(relatedTopics.isNotEmpty())
+    require(contactedBioguideIds.size <= 3)
+    require(firstName.isNotBlank())
+    require(lastName.isNotBlank())
   }
 }

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/model/SendEmailRequest.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/model/SendEmailRequest.kt
@@ -1,10 +1,27 @@
 package org.climatechangemakers.act.feature.action.model
 
 import kotlinx.serialization.Serializable
+import org.climatechangemakers.act.common.model.RepresentedArea
+import org.climatechangemakers.act.feature.communicatewithcongress.model.Prefix
+import org.climatechangemakers.act.feature.communicatewithcongress.model.Topic
 
 @Serializable class SendEmailRequest(
   val originatingEmailAddress: String,
-  val relatedIssueId: Long,
+  val title: Prefix,
+  val firstName: String,
+  val lastName: String,
+  val streetAddress: String,
+  val city: String,
+  val state: RepresentedArea,
+  val postalCode: String,
+  val relatedTopics: List<Topic>,
+  val emailSubject: String,
   val emailBody: String,
+  val relatedIssueId: Long,
   val contactedBioguideIds: List<String>,
-)
+) {
+  init {
+    require(contactedBioguideIds.isNotEmpty())
+    require(relatedTopics.isNotEmpty())
+  }
+}

--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>log/climate-changemakers-act-backend.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>climate-changemakers-act-backend-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>log/climate-changemakers-act-backend-%d{yyyy-MM-dd}.log</fileNamePattern>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
         <encoder>


### PR DESCRIPTION
This commit adds fields necessary to make a (S)CWC contact http call.
Some of this information has already been collected from the user as
part of finding their members of congress -- we should reuse that
information versus redundantly asking for it again.

The `relatedTopics` and `contactedBioguideIds` always expect to have at
least one element in them.

Closes #56
