### PR TITLE
Handle all networking error types for email requests

### DIFF
--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/manager/NetworkCommunicateWithCongressManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/manager/NetworkCommunicateWithCongressManager.kt
@@ -23,7 +23,6 @@ import org.climatechangemakers.act.feature.findlegislator.model.MemberOfCongress
 import org.climatechangemakers.act.feature.issue.manager.IssueManager
 import org.slf4j.Logger
 import retrofit2.HttpException
-import retrofit2.Response
 import javax.inject.Inject
 
 class NetworkCommunicateWithCongressManager @Inject constructor(

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/service/HouseCommunicateWithCongressService.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/service/HouseCommunicateWithCongressService.kt
@@ -7,5 +7,5 @@ import retrofit2.http.POST
 
 interface HouseCommunicateWithCongressService {
 
-  @POST("message") suspend fun contact(@Body request: CommunicateWithCogressRequest): Response<Unit>
+  @POST("message") suspend fun contact(@Body request: CommunicateWithCogressRequest)
 }

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/service/SenateCommunicateWithCongressService.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/service/SenateCommunicateWithCongressService.kt
@@ -7,5 +7,5 @@ import retrofit2.http.POST
 
 interface SenateCommunicateWithCongressService {
 
-  @POST(".") suspend fun contact(@Body request: CommunicateWithCogressRequest): Response<Unit>
+  @POST(".") suspend fun contact(@Body request: CommunicateWithCogressRequest)
 }

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/manager/NetworkCommunicateWithCongressManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/manager/NetworkCommunicateWithCongressManagerTest.kt
@@ -1,7 +1,5 @@
 package org.climatechangemakers.act.feature.communicatewithcongress.manager
 
-import okhttp3.MediaType
-import okhttp3.ResponseBody
 import org.climatechangemakers.act.common.model.Failure
 import org.climatechangemakers.act.common.model.RepresentedArea
 import org.climatechangemakers.act.common.model.Success
@@ -137,9 +135,8 @@ class NetworkCommunicateWithCongressManagerTest {
   }
 
   @Test fun `failed request is returned from sendEmails`() = suspendTest {
-    val error = Response.error<Unit>(500, ResponseBody.create(MediaType.get("application/json"), "error"))
-    val fakeSenteService = FakeCommunicateWithCongressService { error }
-    val fakeHouseService = FakeCommunicateWithCongressService { error }
+    val fakeSenteService = FakeCommunicateWithCongressService { error("foo") }
+    val fakeHouseService = FakeCommunicateWithCongressService { error("blah") }
     val manager = NetworkCommunicateWithCongressManager(
       senateService = fakeSenteService,
       houseService = fakeHouseService,

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/service/FakeCommunicateWithCongressService.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/service/FakeCommunicateWithCongressService.kt
@@ -5,13 +5,13 @@ import org.climatechangemakers.act.feature.communicatewithcongress.model.Communi
 import retrofit2.Response
 
 class FakeCommunicateWithCongressService(
-  private val responseCreator: () -> Response<Unit>,
+  private val action: () -> Unit,
 ) : SenateCommunicateWithCongressService, HouseCommunicateWithCongressService {
 
   val capturedBodies = Channel<CommunicateWithCogressRequest>(Channel.BUFFERED)
 
-  override suspend fun contact(request: CommunicateWithCogressRequest): Response<Unit> {
+  override suspend fun contact(request: CommunicateWithCogressRequest) {
     capturedBodies.trySend(request)
-    return responseCreator()
+    return action()
   }
 }


### PR DESCRIPTION
The error handling in `NetworkCommunicatingWithCongressManager` was
flawed such that if a connection or IO error happened, it wouldn't be
handled correctly. This ultimately led to an improper error response
being sent to the client.

This commit ensures all exceptions are caught and handled correctly. 
