### PR TITLE
Retry if send-email fails

### DIFF
--- a/frontend/src/Pages/TakeAction/SendAnEmail/Prompts.tsx
+++ b/frontend/src/Pages/TakeAction/SendAnEmail/Prompts.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Button, Col, Form, Row } from "react-bootstrap";
 
 type Props = {
+    emailState: EmailState;
     formRef: React.RefObject<HTMLFormElement>;
     setEmailState: React.Dispatch<React.SetStateAction<EmailState>>;
     setEmailBody: (body: string) => void;
@@ -11,7 +12,7 @@ type Props = {
 
 const salutation = "To whom it may concern,";
 
-export default function Prompts({ formRef, setEmailState, setEmailBody }: Props) {
+export default function Prompts({ emailState, formRef, setEmailState, setEmailBody }: Props) {
     const [emailPrompts, setEmailPrompts] = useState({
         policyAsk: "",
         whyItMatters: "",
@@ -113,7 +114,7 @@ export default function Prompts({ formRef, setEmailState, setEmailBody }: Props)
                         Review Email
                     </Button>
                     <HiddenValidationInput
-                        when={Object.values(emailPrompts).every((p) => !p)}
+                        when={emailState === "prompting" && Object.values(emailPrompts).every((p) => !p)}
                         message="Please fill out at least one prompt"
                     />
                 </Col>

--- a/frontend/src/Pages/TakeAction/SendAnEmail/SendAnEmail.tsx
+++ b/frontend/src/Pages/TakeAction/SendAnEmail/SendAnEmail.tsx
@@ -47,6 +47,7 @@ export default function SendAnEmail({
     const [sendEmailError, setSendEmailError] = useState("");
     const [emailState, setEmailState] = useState<EmailState>("titleing");
     const [isSending, setIsSending] = useState(false);
+    const [bioguideIdsToSend, setBioguideIdsToSend] = useState(actionInfo.legislators.map((l) => l.bioguideId));
 
     useEffect(() => {
         emailState === "prompting" && scrollToId("email_prompts");
@@ -72,11 +73,20 @@ export default function SendAnEmail({
             emailInfo.subject,
             emailInfo.body,
             selectedIssue.id,
-            actionInfo.legislators.map((l) => l.bioguideId)
+            bioguideIdsToSend
         );
         setIsSending(false);
 
         if (!response.successful) {
+            if (typeof response.error === "object") {
+                setBioguideIdsToSend(response.error.failedBioguideIds);
+                setSendEmailError(
+                    `Failed to send ${response.error.failedBioguideIds.length} email${
+                        response.error.failedBioguideIds.length > 1 ? "s" : ""
+                    }. Click to retry.`
+                );
+                return;
+            }
             setSendEmailError(response?.error ?? "Failed to send email");
             return;
         }

--- a/frontend/src/Pages/TakeAction/SendAnEmail/SendAnEmail.tsx
+++ b/frontend/src/Pages/TakeAction/SendAnEmail/SendAnEmail.tsx
@@ -46,6 +46,7 @@ export default function SendAnEmail({
     });
     const [sendEmailError, setSendEmailError] = useState("");
     const [emailState, setEmailState] = useState<EmailState>("titleing");
+    const [isSending, setIsSending] = useState(false);
 
     useEffect(() => {
         emailState === "prompting" && scrollToId("email_prompts");
@@ -56,6 +57,8 @@ export default function SendAnEmail({
     const sendEmail = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         setSendEmailError("");
+
+        setIsSending(true);
         const response = await sendEmailAPI(
             formInfo.email,
             emailInfo.prefix,
@@ -71,6 +74,8 @@ export default function SendAnEmail({
             selectedIssue.id,
             actionInfo.legislators.map((l) => l.bioguideId)
         );
+        setIsSending(false);
+
         if (!response.successful) {
             setSendEmailError(response?.error ?? "Failed to send email");
             return;
@@ -251,6 +256,7 @@ export default function SendAnEmail({
                 </Row>
                 {emailState !== "titleing" && (
                     <Prompts
+                        emailState={emailState}
                         formRef={formRef}
                         setEmailState={setEmailState}
                         setEmailBody={(body: string) => setEmailInfo((info) => ({ ...info, body }))}
@@ -288,7 +294,7 @@ export default function SendAnEmail({
                             </Col>
                             <Col>
                                 <Button type="submit" className="w-100 text-dark" disabled={isEmailSent}>
-                                    {!sendEmailError ? "Send Email" : "Try again"}
+                                    {isSending ? "Sending..." : !sendEmailError ? "Send Email" : "Try again"}
                                 </Button>
                             </Col>
                         </Row>

--- a/frontend/src/common/api/ClimateChangemakersAPI.ts
+++ b/frontend/src/common/api/ClimateChangemakersAPI.ts
@@ -1,10 +1,10 @@
 import { ActionInfo } from "common/models/ActionInfo";
 import { FormInfo } from "common/models/FormInfo";
 
-type FetchResponse<T> = {
+type FetchResponse<Data, Error = string> = {
     successful: boolean;
-    error?: string;
-    data?: T;
+    error?: Error;
+    data?: Data;
 };
 
 export type ErrorResponse = Error & {
@@ -24,15 +24,15 @@ export const fetcher = async <T>(path: string) => {
     return (await res.json()) as T;
 };
 
-const parseFetch = async <T>(response: Response): Promise<FetchResponse<T>> => {
+const parseFetch = async <Data, Error = string>(response: Response): Promise<FetchResponse<Data, Error>> => {
     try {
-        if (!response.ok) return { successful: false };
+        if (!response.ok) return { successful: false, error: (await response.json()) as Error };
 
         if (response.status === 204) return { successful: true };
 
         return {
             successful: true,
-            data: (await response.json()) as T,
+            data: (await response.json()) as Data,
         };
     } catch (e: any) {
         return { successful: false, error: e?.message };

--- a/frontend/src/common/api/ClimateChangemakersAPI.ts
+++ b/frontend/src/common/api/ClimateChangemakersAPI.ts
@@ -52,9 +52,11 @@ const post = async <Data, Error = string>(path: string, content: Object): Promis
 
 const retryThreeTimes = async <Data, Error = string>(fetch: () => Promise<FetchResponse<Data, Error>>) => {
     let response = await fetch();
-    for (var i = 0; i < 3; i++) {
-        response = await fetch();
-        if (response.successful) return response;
+    if (!response.successful) {
+        for (var i = 0; i < 3; i++) {
+            response = await fetch();
+            if (response.successful) return response;
+        }
     }
     return response;
 };


### PR DESCRIPTION
Closes #171 and #101

- Addressed #171 by only requiring prompt values if you are on the prompt step (i.e. once you've finished/skipped the prompt step, prompts are no longer required)
- Improved `post` request type handling to handle Objects (necessary to get back `failedBioguideIds` array from `/send-email`)
- Retry `send-email` three times if the first call fails (for a total of 4 possible attempts)