### PR TITLE
Fix safari image size

### DIFF
--- a/frontend/src/Pages/PickYourIssue/Issue.tsx
+++ b/frontend/src/Pages/PickYourIssue/Issue.tsx
@@ -21,7 +21,7 @@ export default function IssueCard({ onClick, issue, selectedIssue, focusIssue }:
             })}
         >
             <div
-                className={cx({
+                className={cx("d-flex", {
                     [styles.focusImageContainer]: focusIssue,
                 })}
             >


### PR DESCRIPTION
Closes #204 

How it looks now in Safari:

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/31449177/145751175-28c967fd-6fbc-4b96-90ee-1bf6ea1a73f3.png">

