### PR TITLE
Fix wrong migration paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,23 +19,23 @@ cache:
     - ./backend/.gradle/wrapper
     - ./backend/.gradle/caches
 
-      # test-backend:
-      #   image: openjdk:11.0.12
-      #   stage: test
-      #   script: 
-      #     - cd backend
-      #     - ./gradlew test
-      #   only: 
-      #     - trunk 
-      #     - external_pull_requests
-      # 
-      # build-production-container:
-      #   image: docker:stable
-      #   stage: build
-      #   script: 
-      #     - docker build -t "$IMAGE_TAG:$CI_COMMIT_SHORT_SHA" .
-      #   only: 
-      #     - external_pull_requests
+test-backend:
+  image: openjdk:11.0.12
+  stage: test
+  script: 
+    - cd backend
+    - ./gradlew test
+  only: 
+    - trunk 
+    - external_pull_requests
+
+build-production-container:
+  image: docker:stable
+  stage: build
+  script: 
+    - docker build -t "$IMAGE_TAG:$CI_COMMIT_SHORT_SHA" .
+  only: 
+    - external_pull_requests
 
 publish-production-container:
   image: docker:stable
@@ -62,8 +62,8 @@ migrate-production-database:
     - cp backend/src/main/sqldelight/migrations/*.sqm backend/build/resources/main/migrations/
     - find backend/build/resources/main/migrations/ -name "*.sqm" -exec sh -c 'mv "$1" "${1%.sqm}.sql"' _ {} \;
     - flyway -user=${POSTGRES_USER} -password=${POSTGRES_PASSWORD} -table=schema_history -locations=backend/build/resources/main/migrations/ -url=${POSTGRES_URL} migrate
-      # only: 
-      #   refs:
-      #     - trunk
-      #   changes:
-      #     - backend/src/main/sqldelight/migrations/*.sqm
+  only: 
+    refs:
+      - trunk
+    changes:
+      - backend/src/main/sqldelight/migrations/*.sqm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ migrate-production-database:
     - mkdir -p backend/build/resources/main/migrations/
     - cp backend/src/main/sqldelight/migrations/*.sqm backend/build/resources/main/migrations/
     - find backend/build/resources/main/migrations/ -name "*.sqm" -exec sh -c 'mv "$1" "${1%.sqm}.sql"' _ {} \;
-    - flyway -user=${POSTGRES_USER} -password=${POSTGRES_PASSWORD} -table=schema_history -locations=./backend/build/resources/main/migrations/ -url=${POSTGRES_URL} migrate
+    - flyway -user=${POSTGRES_USER} -password=${POSTGRES_PASSWORD} -table=schema_history -locations=backend/build/resources/main/migrations/ -url=${POSTGRES_URL} migrate
       # only: 
       #   refs:
       #     - trunk

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,23 +19,23 @@ cache:
     - ./backend/.gradle/wrapper
     - ./backend/.gradle/caches
 
-test-backend:
-  image: openjdk:11.0.12
-  stage: test
-  script: 
-    - cd backend
-    - ./gradlew test
-  only: 
-    - trunk 
-    - external_pull_requests
-
-build-production-container:
-  image: docker:stable
-  stage: build
-  script: 
-    - docker build -t "$IMAGE_TAG:$CI_COMMIT_SHORT_SHA" .
-  only: 
-    - external_pull_requests
+      # test-backend:
+      #   image: openjdk:11.0.12
+      #   stage: test
+      #   script: 
+      #     - cd backend
+      #     - ./gradlew test
+      #   only: 
+      #     - trunk 
+      #     - external_pull_requests
+      # 
+      # build-production-container:
+      #   image: docker:stable
+      #   stage: build
+      #   script: 
+      #     - docker build -t "$IMAGE_TAG:$CI_COMMIT_SHORT_SHA" .
+      #   only: 
+      #     - external_pull_requests
 
 publish-production-container:
   image: docker:stable
@@ -62,8 +62,8 @@ migrate-production-database:
     - cp backend/src/main/sqldelight/migrations/*.sqm backend/build/resources/main/migrations/
     - find backend/build/resources/main/migrations/ -name "*.sqm" -exec sh -c 'mv "$1" "${1%.sqm}.sql"' _ {} \;
     - flyway -user=${POSTGRES_USER} -password=${POSTGRES_PASSWORD} -table=schema_history -locations=./backend/build/resources/main/migrations/ -url=${POSTGRES_URL} migrate
-  only: 
-    refs:
-      - trunk
-    changes:
-      - backend/src/main/sqldelight/migrations/*.sqm
+      # only: 
+      #   refs:
+      #     - trunk
+      #   changes:
+      #     - backend/src/main/sqldelight/migrations/*.sqm


### PR DESCRIPTION
For some reason, Flyway couldn't open migration files aliased by `./` in their path. This commit removes those relative paths and everything seems to work. 