### PR TITLE
Update production container /etc/hosts for HCWC

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ build-production-container:
   image: docker:stable
   stage: build
   script: 
-    - docker build -t "$IMAGE_TAG:$CI_COMMIT_SHORT_SHA" .
+    - docker build --build-arg nginx_proxy_host=${NGINX_PROXY_HOST} -t "$IMAGE_TAG:$CI_COMMIT_SHORT_SHA" .
   only: 
     - external_pull_requests
 
@@ -45,7 +45,7 @@ publish-production-container:
     LATEST_IMAGE: "$IMAGE_TAG:latest"
   script: 
     - docker login -u $GITLAB_USER_LOGIN -p $GITLAB_API_KEY registry.gitlab.com 
-    - docker build -t $TAGGED_IMAGE .
+    - docker build --build-arg nginx_proxy_host=${NGINX_PROXY_HOST} -t $TAGGED_IMAGE .
     - docker tag $TAGGED_IMAGE $LATEST_IMAGE
     - docker push $IMAGE_TAG
   only: 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ build-production-container:
   image: docker:stable
   stage: build
   script: 
-    - docker build --build-arg nginx_proxy_host=${NGINX_PROXY_HOST} -t "$IMAGE_TAG:$CI_COMMIT_SHORT_SHA" .
+    - docker build --build-arg cwc_proxy_host=${CWC_PROXY_HOST} -t "$IMAGE_TAG:$CI_COMMIT_SHORT_SHA" .
   only: 
     - external_pull_requests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ WORKDIR /app
 ARG nginx_proxy_host
 
 RUN echo "echo ${nginx_proxy_host} cwc.house.gov >> /etc/hosts" >> /tmp/update_hosts.sh
+RUN echo "echo ${nginx_proxy_host} soapbox.senate.gov >> /etc/hosts" >> /tmp/update_hosts.sh
 RUN chmod 777 /tmp/update_hosts.sh
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,10 @@ COPY --from=build_backend /appbuild/build/libs/climatechangemakers-backend*all.j
 COPY --from=build_backend /appbuild/build/resources/ /app/resources/
 WORKDIR /app
 
-CMD ["sh", "-c", "java -server -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:InitialRAMFraction=2 -XX:MinRAMFraction=2 -XX:MaxRAMFraction=2 -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:+UseStringDeduplication -jar climatechangemakers-backend.jar"]
+ARG nginx_proxy_host
+
+RUN echo "echo ${nginx_proxy_host} cwc.house.gov >> /etc/hosts" >> /tmp/update_hosts.sh
+RUN chmod 777 /tmp/update_hosts.sh
+
+USER root
+ENTRYPOINT ["/bin/sh", "-c", "cat /tmp/update_hosts.sh && /tmp/update_hosts.sh && exec java -server -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:InitialRAMFraction=2 -XX:MinRAMFraction=2 -XX:MaxRAMFraction=2 -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:+UseStringDeduplication -jar climatechangemakers-backend.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,10 @@ COPY --from=build_backend /appbuild/build/libs/climatechangemakers-backend*all.j
 COPY --from=build_backend /appbuild/build/resources/ /app/resources/
 WORKDIR /app
 
-ARG nginx_proxy_host
+ARG cwc_proxy_host
 
-RUN echo "echo ${nginx_proxy_host} cwc.house.gov >> /etc/hosts" >> /tmp/update_hosts.sh
-RUN echo "echo ${nginx_proxy_host} soapbox.senate.gov >> /etc/hosts" >> /tmp/update_hosts.sh
+RUN echo "echo ${cwc_proxy_host} cwc.house.gov >> /etc/hosts" >> /tmp/update_hosts.sh
+RUN echo "echo ${cwc_proxy_host} soapbox.senate.gov >> /etc/hosts" >> /tmp/update_hosts.sh
 RUN chmod 777 /tmp/update_hosts.sh
 
 USER root


### PR DESCRIPTION
House Communicating with Congress API requires a whitelisted
IP address. Therefore, Climate Changemakers requires that we have
infrastructure stable enough to always send reqeusts to HCWC from the
same IP address.

This commit ammends the `/etc/hosts` file of our production container so
that requests going to `cwc.house.gov` get proxied through a stable EC2
instance.

Closes #236
