### PR TITLE
Remove Gradle Plugin Portal

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -6,7 +6,7 @@ val kotlin_version: String by project
 val logback_version: String by project
 
 buildscript {
-    repositories { gradlePluginPortal() }
+    repositories { mavenCentral() }
     dependencies {
         classpath("gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0")
         classpath("com.squareup.sqldelight:gradle-plugin:1.5.2")


### PR DESCRIPTION
Gradle plugin portal was having network issues today which caused builds
to fail. There's no reason we should depending on this for our classpath
dependencies, and not using `mavenCentral` directly.
