### PR TITLE
Retain eips from public private vpc on networking stack deletion

### DIFF
--- a/cloudformation/public-private-vpc.yml
+++ b/cloudformation/public-private-vpc.yml
@@ -128,11 +128,15 @@ Resources:
   # each private subnet.
   NatGatewayOneAttachment:
     Type: AWS::EC2::EIP
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     DependsOn: GatewayAttachement
     Properties:
         Domain: vpc
   NatGatewayTwoAttachment:
     Type: AWS::EC2::EIP
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     DependsOn: GatewayAttachement
     Properties:
         Domain: vpc


### PR DESCRIPTION
We'd like to keep these EIPs around so that we can assign one of them to our SCWC and HCWC proxy box https://us-west-2.console.aws.amazon.com/ec2/v2/home?region=us-west-2#InstanceDetails:instanceId=i-0af64e54f5af0e1d5, since these two EIPs are whitelisted source ips from the HCWC perspective.