### PR TITLE
Apply migrations in development containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,55 @@
 version: '3'
 
 services:
-    frontend:
-      build: ./frontend
-      image: frontend:latest
-      ports:
-        - ${REACT_APP_PORT}:3000
-    backend:
-      build: ./backend
-      image: backend:latest
-      environment:
-        - GEOCODIO_API_KEY=${GEOCODIO_API_KEY}
-        - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-        - POSTGRES_USER=${POSTGRES_USER}
-        - POSTGRES_DB=${POSTGRES_DB} 
-        - POSTGRES_HOSTNAME=${POSTGRES_HOSTNAME}
-        - POSTGRES_PORT=${POSTGRES_PORT}
-        - SCWC_API_KEY=${SCWC_API_KEY}
-        - SCWC_URL=${SCWC_URL}
-        - HCWC_API_KEY=${HCWC_API_KEY}
-        - HCWC_URL=${HCWC_URL}
-        - AIRTABLE_API_KEY=${AIRTABLE_API_KEY}
-        - AIRTABLE_BASE_ID=${AIRTABLE_BASE_ID}
-        - MAILCHIMP_API_KEY=${MAILCHIMP_API_KEY}
-        - MAILCHIMP_URL=${MAILCHIMP_URL}
-        - MAILCHIMP_AUDIENCE_ID=${MAILCHIMP_AUDIENCE_ID}
-      ports:
-        - ${KOTLIN_PORT}:8080
-    database:
-      build: ./database
-      image: database:latest
-      environment: 
-        - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-        - POSTGRES_USER=${POSTGRES_USER}
-        - POSTGRES_DB=${POSTGRES_DB} 
-      ports:
-        - ${POSTGRES_PORT}:5432
+  frontend:
+    build: ./frontend
+    image: frontend:latest
+    ports:
+      - ${REACT_APP_PORT}:3000
+
+  backend:
+    build: ./backend
+    image: backend:latest
+    environment:
+      - GEOCODIO_API_KEY=${GEOCODIO_API_KEY}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB} 
+      - POSTGRES_HOSTNAME=${POSTGRES_HOSTNAME}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+      - SCWC_API_KEY=${SCWC_API_KEY}
+      - SCWC_URL=${SCWC_URL}
+      - HCWC_API_KEY=${HCWC_API_KEY}
+      - HCWC_URL=${HCWC_URL}
+      - AIRTABLE_API_KEY=${AIRTABLE_API_KEY}
+      - AIRTABLE_BASE_ID=${AIRTABLE_BASE_ID}
+      - MAILCHIMP_API_KEY=${MAILCHIMP_API_KEY}
+      - MAILCHIMP_URL=${MAILCHIMP_URL}
+      - MAILCHIMP_AUDIENCE_ID=${MAILCHIMP_AUDIENCE_ID}
+    ports:
+      - ${KOTLIN_PORT}:8080
+
+  database:
+    build: ./database
+    image: database:latest
+    environment: 
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB} 
+    ports:
+      - ${POSTGRES_PORT}:5432
+
+  migration:
+    build: ./flyway
+    image: flyway-migration:latest
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB} 
+      - POSTGRES_HOSTNAME=${POSTGRES_HOSTNAME}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+    restart: on-failure:5
+    volumes: 
+      - ./backend:/flyway/backend:ro
+    depends_on: 
+      - database

--- a/flyway/Dockerfile
+++ b/flyway/Dockerfile
@@ -1,0 +1,5 @@
+FROM flyway/flyway:8.2.2-alpine
+
+COPY migrate.sh . 
+
+ENTRYPOINT [ "./migrate.sh" ]

--- a/flyway/migrate.sh
+++ b/flyway/migrate.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Allocate a new temporary directory for the migration files. 
+tmp_dir=$(mktemp -d -t migrations-XXXXXX)
+
+# Move the SQLDelight migrations to the temporary directory. 
+cp backend/src/main/sqldelight/migrations/*.sqm $tmp_dir 
+
+# Rename the .sqm files in tmp_dir to .sql files. This assumes that are valid SQL. 
+find $tmp_dir -name "*.sqm" -exec sh -c 'mv "$1" "${1%.sqm}.sql"' _ {} \;
+
+ls -la $tmp_dir
+
+# Build the jdbc URI.
+POSTGRES_URL="jdbc:postgresql://${POSTGRES_HOSTNAME}:${POSTGRES_PORT}/${POSTGRES_DB}"
+
+# Initiate the migration. 
+flyway -user=${POSTGRES_USER} \
+       -X \
+       -password=${POSTGRES_PASSWORD} \
+       -table=schema_history \
+       -locations="filesystem:$tmp_dir" \
+       -url=${POSTGRES_URL} \
+       migrate

--- a/flyway/migrate.sh
+++ b/flyway/migrate.sh
@@ -6,17 +6,14 @@ tmp_dir=$(mktemp -d -t migrations-XXXXXX)
 # Move the SQLDelight migrations to the temporary directory. 
 cp backend/src/main/sqldelight/migrations/*.sqm $tmp_dir 
 
-# Rename the .sqm files in tmp_dir to .sql files. This assumes that are valid SQL. 
+# Rename the .sqm files in tmp_dir to .sql files. This assumes they are valid SQL. 
 find $tmp_dir -name "*.sqm" -exec sh -c 'mv "$1" "${1%.sqm}.sql"' _ {} \;
-
-ls -la $tmp_dir
 
 # Build the jdbc URI.
 POSTGRES_URL="jdbc:postgresql://${POSTGRES_HOSTNAME}:${POSTGRES_PORT}/${POSTGRES_DB}"
 
 # Initiate the migration. 
 flyway -user=${POSTGRES_USER} \
-       -X \
        -password=${POSTGRES_PASSWORD} \
        -table=schema_history \
        -locations="filesystem:$tmp_dir" \


### PR DESCRIPTION
Until now, we've relied on manually dumping the schema of the production
database to synchronize our local development environments.

This commit will apply migrations via `flyway` as part of
`docker-compose up`.

Closes #194.
