### PR TITLE
Deduplicate Mailchimp newsletter subscriptions

### DIFF
--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/email/manager/MailchimpEmailEnrollmentManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/email/manager/MailchimpEmailEnrollmentManager.kt
@@ -1,5 +1,6 @@
 package org.climatechangemakers.act.feature.email.manager
 
+import okio.ByteString
 import org.climatechangemakers.act.common.model.RepresentedArea
 import org.climatechangemakers.act.di.Mailchimp
 import org.climatechangemakers.act.feature.email.model.SubscribeChangemakerRequest
@@ -20,6 +21,7 @@ class MailchimpEmailEnrollmentManager @Inject constructor(
     val request = SubscribeChangemakerRequest(email, firstName, lastName, state)
     mailchimpService.subscribeChangemaker(
       audienceId = changemakersMailchimpAudienceId,
+      emailMd5Hash = ByteString.of(*email.lowercase().encodeToByteArray()).md5().hex(),
       request = request,
     )
   }

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/email/service/MailchimpService.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/email/service/MailchimpService.kt
@@ -1,15 +1,16 @@
 package org.climatechangemakers.act.feature.email.service
 
 import org.climatechangemakers.act.feature.email.model.SubscribeChangemakerRequest
-import retrofit2.http.Body
-import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
+import retrofit2.http.Body
 
 interface MailchimpService {
 
-  @POST("lists/{audience_id}/members/")
+  @PUT("lists/{audience_id}/members/{email_md5_hash_string}")
   suspend fun subscribeChangemaker(
     @Path("audience_id") audienceId: String,
-    @Body request: SubscribeChangemakerRequest
+    @Path("email_md5_hash_string") emailMd5Hash: String,
+    @Body request: SubscribeChangemakerRequest,
   )
 }

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/email/manager/MailchimpEmailEnrollmentManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/email/manager/MailchimpEmailEnrollmentManagerTest.kt
@@ -21,9 +21,21 @@ class MailchimpEmailEnrollmentManagerTest {
     )
 
     assertEquals("some_id", service.capturedAudienceIds.receive())
+    assertEquals("4f64c9f81bb0d4ee969aaf7b4a5a6f40", service.capturedEmailHashes.receive())
     assertEquals(
       SubscribeChangemakerRequest("email@email.com", "foo", "bar", RepresentedArea.Alabama),
       service.capturedRequestBodies.receive(),
     )
+  }
+
+  @Test fun `manager calls service with hash of lowercase email address`() = suspendTest {
+    manager.subscribeChangemaker(
+      email = "EMAIL@email.com",
+      firstName = "foo",
+      lastName = "bar",
+      state = RepresentedArea.Alabama,
+    )
+
+    assertEquals("4f64c9f81bb0d4ee969aaf7b4a5a6f40", service.capturedEmailHashes.receive())
   }
 }

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/email/service/FakeMailchimpService.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/email/service/FakeMailchimpService.kt
@@ -7,9 +7,15 @@ class FakeMailchimpService : MailchimpService {
 
   val capturedAudienceIds = Channel<String>(Channel.UNLIMITED)
   val capturedRequestBodies = Channel<SubscribeChangemakerRequest>(Channel.UNLIMITED)
+  val capturedEmailHashes = Channel<String>(Channel.UNLIMITED)
 
-  override suspend fun subscribeChangemaker(audienceId: String, request: SubscribeChangemakerRequest) {
+  override suspend fun subscribeChangemaker(
+    audienceId: String,
+    emailMd5Hash: String,
+    request: SubscribeChangemakerRequest,
+  ) {
     capturedAudienceIds.trySend(audienceId)
     capturedRequestBodies.trySend(request)
+    capturedEmailHashes.trySend(emailMd5Hash)
   }
 }


### PR DESCRIPTION
It's possible that a Changemaker could already be subscribed for our
newsletter. If this was the case, Mailchimp would fail to sign a new
changemaker up in our audience because of a data conflict.

This commit uniquely identifies a changemaker by taking the MD5 hash of
their email address.

Closes #279
