### PR TITLE
Record Congressional Email Delivery ID

### DIFF
--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/manager/ActionTrackerManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/manager/ActionTrackerManager.kt
@@ -8,6 +8,7 @@ interface ActionTrackerManager {
     email: String,
     contactedBioguideId: String,
     relatedIssueId: Long,
+    emailDeliveryId: String,
   )
 
   suspend fun trackActionPhoneCall(

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/manager/DatabaseActionTrackerManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/manager/DatabaseActionTrackerManager.kt
@@ -26,8 +26,9 @@ class DatabaseActionTrackerManager @Inject constructor(
     email: String,
     contactedBioguideId: String,
     relatedIssueId: Long,
+    emailDeliveryId: String,
   ) = withContext(ioDispatcher) {
-    actionEmailLegislatorQueries.insert(email, relatedIssueId, contactedBioguideId)
+    actionEmailLegislatorQueries.insert(email, relatedIssueId, contactedBioguideId, emailDeliveryId)
   }
 
   override suspend fun trackActionPhoneCall(

--- a/backend/src/main/sqldelight/migrations/V3__add_email_delivery_id.sqm
+++ b/backend/src/main/sqldelight/migrations/V3__add_email_delivery_id.sqm
@@ -1,0 +1,2 @@
+ALTER TABLE action_email_legislator
+ADD COLUMN email_delivery_id VARCHAR;

--- a/backend/src/main/sqldelight/org/climatechangemakers/act/database/ActionEmailLegislator.sq
+++ b/backend/src/main/sqldelight/org/climatechangemakers/act/database/ActionEmailLegislator.sq
@@ -1,5 +1,6 @@
 CREATE TABLE action_email_legislator(
-  action_contact_legislator_id BIGINT NOT NULL REFERENCES action_contact_legislator(id) ON DELETE CASCADE
+  action_contact_legislator_id BIGINT NOT NULL REFERENCES action_contact_legislator(id) ON DELETE CASCADE,
+  email_delivery_id VARCHAR
 );
 
 insert:
@@ -9,4 +10,4 @@ WITH items AS (
   RETURNING id
 )
 INSERT INTO action_email_legislator
-SELECT id FROM items;
+SELECT id, :deliveryId FROM items;

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/action/manager/DatabaseActionTrackerManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/action/manager/DatabaseActionTrackerManagerTest.kt
@@ -16,7 +16,7 @@ class DatabaseActionTrackerManagerTest : TestContainerProvider() {
   @Test fun `email action entries are recorded in both tables`() = suspendTest {
     val id = driver.insertIssue("this is an issue", "tweet", "url.com")
     driver.insertMemberOfCongress(DEFAULT_MEMBER_OF_CONGRESS.copy(bioguideId = "hello"))
-    manager.trackActionSendEmail("foo@foo.com", "hello", id)
+    manager.trackActionSendEmail("foo@foo.com", "hello", id, "someDeliveryId")
 
     assertEquals(
       "hello",
@@ -26,12 +26,23 @@ class DatabaseActionTrackerManagerTest : TestContainerProvider() {
       }
     )
 
+    val query = driver.executeQuery(
+      0,
+      "SELECT action_contact_legislator_id, email_delivery_id FROM action_email_legislator",
+      0
+    )
+
     assertEquals(
       id,
-      driver.executeQuery(0, "SELECT action_contact_legislator_id FROM action_email_legislator", 0).let {
+      query.let {
         it.next()
         it.getLong(0)
       }
+    )
+
+    assertEquals(
+      "someDeliveryId",
+      query.getString(1),
     )
   }
 

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/action/manager/FakeActionTrackerManager.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/action/manager/FakeActionTrackerManager.kt
@@ -7,12 +7,19 @@ class FakeActionTrackerManager : ActionTrackerManager {
   val capturedEmail = Channel<String>(capacity = Channel.BUFFERED)
   val capturedBioguideId = Channel<String>(capacity = Channel.BUFFERED)
   val capturedIssueId = Channel<Long>(capacity = Channel.BUFFERED)
+  val capturedEmailDeliveryIds = Channel<String>(capacity = Channel.BUFFERED)
 
   override suspend fun trackActionInitiated(email: String): Unit = TODO("Not yet implemented")
-  override suspend fun trackActionSendEmail(email: String, contactedBioguideId: String, relatedIssueId: Long) {
+  override suspend fun trackActionSendEmail(
+    email: String,
+    contactedBioguideId: String,
+    relatedIssueId: Long,
+    emailDeliveryId: String,
+  ) {
     capturedEmail.trySend(email)
     capturedBioguideId.trySend(contactedBioguideId)
     capturedIssueId.trySend(relatedIssueId)
+    capturedEmailDeliveryIds.trySend(emailDeliveryId)
   }
 
   override suspend fun trackActionPhoneCall(

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/manager/NetworkCommunicateWithCongressManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/manager/NetworkCommunicateWithCongressManagerTest.kt
@@ -18,6 +18,7 @@ import org.junit.Test
 import org.slf4j.LoggerFactory
 import retrofit2.Response
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class NetworkCommunicateWithCongressManagerTest {
@@ -175,5 +176,6 @@ class NetworkCommunicateWithCongressManagerTest {
     assertEquals(email, capturedEmail.receive())
     assertEquals(bioguide, capturedBioguideId.receive())
     assertEquals(issueId, capturedIssueId.receive())
+    assertNotNull(capturedEmailDeliveryIds.tryReceive().getOrNull())
   }
 }


### PR DESCRIPTION
We should be storing these IDs for debugging purposes. In the event that
an email doesn't get delivered where it's supposed to (looking at you
Geocod.io), we need to be able to hunt down what happened.

Closes #262
