### PR TITLE
Revert back to using XML version 1.0

### DIFF
--- a/backend/src/main/kotlin/org/climatechangemakers/act/di/SerializationModule.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/di/SerializationModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.serialization.json.Json
 import nl.adaptivity.xmlutil.XmlDeclMode
+import nl.adaptivity.xmlutil.core.XmlVersion
 import nl.adaptivity.xmlutil.serialization.XML
 import okhttp3.MediaType
 import retrofit2.Converter
@@ -23,5 +24,6 @@ import retrofit2.Converter
   @Provides fun providesXml(): XML = XML {
     indentString = "  "
     xmlDeclMode = XmlDeclMode.Charset
+    xmlVersion = XmlVersion.XML10
   }
 }

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/CommunicateWithCongressSerializationTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/communicatewithcongress/model/CommunicateWithCongressSerializationTest.kt
@@ -2,8 +2,10 @@ package org.climatechangemakers.act.feature.communicatewithcongress.model
 
 import kotlinx.serialization.encodeToString
 import nl.adaptivity.xmlutil.XmlDeclMode
+import nl.adaptivity.xmlutil.core.XmlVersion
 import nl.adaptivity.xmlutil.serialization.XML
 import org.climatechangemakers.act.common.model.RepresentedArea
+import org.climatechangemakers.act.di.SerializationModule
 import org.junit.Test
 import java.util.Calendar
 import java.util.Calendar.JANUARY
@@ -12,11 +14,7 @@ import kotlin.test.assertEquals
 
 class CommunicateWithCongressSerializationTest {
 
-  private val xml = XML {
-    xmlDeclMode = XmlDeclMode.Charset
-    indentString = " "
-    indent = 2
-  }
+  private val xml = SerializationModule.providesXml()
 
   @Test fun `sample object structure serializes correctly`() {
     val request = CommunicateWithCogressRequest(
@@ -55,7 +53,7 @@ class CommunicateWithCongressSerializationTest {
 
     assertEquals(
       """
-        |<?xml version="1.1" encoding="UTF-8"?>
+        |<?xml version="1.0" encoding="UTF-8"?>
         |<CWC>
         |  <CWCVersion>2.0</CWCVersion>
         |  <Delivery>


### PR DESCRIPTION
The House side of CWC rejects emails with XML version 1.1. This commit
reverts our XML encoding version back to 1.0.
