### PR TITLE
Use Google Civic Information API

### DIFF
--- a/backend/src/main/kotlin/org/climatechangemakers/act/di/Environment.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/di/Environment.kt
@@ -9,6 +9,7 @@ fun getEnvironmentVariable(
 
 enum class EnvironmentVariable(val key: String) {
   GeocodioApiKey("GEOCODIO_API_KEY"),
+  GoogleCivicApiKey("GOOGLE_CIVIC_API_KEY"),
   SCWCApiKey("SCWC_API_KEY"),
   SCWCUrl("SCWC_URL"),
   HCWCApiKey("HCWC_API_KEY"),

--- a/backend/src/main/kotlin/org/climatechangemakers/act/di/Qualifiers.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/di/Qualifiers.kt
@@ -10,6 +10,11 @@ annotation class Geocodio
 @Qualifier
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
+annotation class GoogleCivic
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
 annotation class Senate
 
 @Qualifier

--- a/backend/src/main/kotlin/org/climatechangemakers/act/di/ServiceModule.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/di/ServiceModule.kt
@@ -9,9 +9,11 @@ import okhttp3.*
 import org.climatechangemakers.act.feature.communicatewithcongress.service.HouseCommunicateWithCongressService
 import org.climatechangemakers.act.feature.communicatewithcongress.service.SenateCommunicateWithCongressService
 import org.climatechangemakers.act.feature.email.service.MailchimpService
+import org.climatechangemakers.act.feature.findlegislator.service.GoogleCivicService
 import org.climatechangemakers.act.feature.membership.service.AirtableService
 import org.slf4j.Logger
 import retrofit2.Converter
+import retrofit2.Converter.Factory
 import retrofit2.Retrofit
 
 @Module object ServiceModule {
@@ -53,6 +55,22 @@ import retrofit2.Retrofit
     logger.info("${newRequest.method()} ${newRequest.url().redactAndRetainPath()}")
     chain.proceed(newRequest)
   }.build()
+
+  @Provides @GoogleCivic fun providesGoogleCividClient(logger: Logger): OkHttpClient = createUrlApiKeyOkHttpClient(
+    apiKeyName = "key",
+    apiKey = getEnvironmentVariable(EnvironmentVariable.GoogleCivicApiKey),
+    logger = logger,
+  )
+
+  @Provides fun providesGoogleCivicService(
+    @GoogleCivic client: OkHttpClient,
+    jsonConverterFactory: Factory,
+  ): GoogleCivicService = Retrofit.Builder()
+    .baseUrl("https://civicinfo.googleapis.com/civicinfo/v2/")
+    .addConverterFactory(jsonConverterFactory)
+    .client(client)
+    .build()
+    .create(GoogleCivicService::class.java)
 
   @Provides @Geocodio fun providesGeocodioClient(logger: Logger): OkHttpClient = createUrlApiKeyOkHttpClient(
     apiKeyName = "api_key",

--- a/backend/src/main/kotlin/org/climatechangemakers/act/di/ServiceModule.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/di/ServiceModule.kt
@@ -56,7 +56,7 @@ import retrofit2.Retrofit
     chain.proceed(newRequest)
   }.build()
 
-  @Provides @GoogleCivic fun providesGoogleCividClient(logger: Logger): OkHttpClient = createUrlApiKeyOkHttpClient(
+  @Provides @GoogleCivic fun providesGoogleCivicClient(logger: Logger): OkHttpClient = createUrlApiKeyOkHttpClient(
     apiKeyName = "key",
     apiKey = getEnvironmentVariable(EnvironmentVariable.GoogleCivicApiKey),
     logger = logger,

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/model/InitiateActionResponse.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/action/model/InitiateActionResponse.kt
@@ -1,9 +1,9 @@
 package org.climatechangemakers.act.feature.action.model
 
-import org.climatechangemakers.act.feature.findlegislator.model.Legislator
+import org.climatechangemakers.act.feature.findlegislator.model.MemberOfCongressDto
 import kotlinx.serialization.Serializable
 
 @Serializable class InitiateActionResponse(
   val initiatorEmail: String,
-  val legislators: List<Legislator>,
+  val legislators: List<MemberOfCongressDto>,
 )

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseMemberOfCongressManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseMemberOfCongressManager.kt
@@ -1,6 +1,7 @@
 package org.climatechangemakers.act.feature.findlegislator.manager
 
 import kotlinx.coroutines.withContext
+import org.climatechangemakers.act.common.model.RepresentedArea
 import org.climatechangemakers.act.database.Database
 import org.climatechangemakers.act.di.Io
 import org.climatechangemakers.act.feature.findlegislator.model.LegislatorRole
@@ -17,5 +18,16 @@ class DatabaseMemberOfCongressManager @Inject constructor(
 
   override suspend fun getMemberOfCongressForBioguide(bioguideId: String) = withContext(ioDispatcher) {
     memberOfCongressQueries.selectForBioguide(bioguideId, ::MemberOfCongress).executeAsOne()
+  }
+
+  override suspend fun getMembersForCongressionalDistrict(
+    state: RepresentedArea,
+    district: Short,
+  ): List<MemberOfCongress> = withContext(ioDispatcher) {
+    memberOfCongressQueries.selectForCongressionalDistrict(
+      state = state,
+      congressionalDistrict = district,
+      mapper = ::MemberOfCongress,
+    ).executeAsList()
   }
 }

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/MemberOfCongressManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/MemberOfCongressManager.kt
@@ -1,7 +1,16 @@
 package org.climatechangemakers.act.feature.findlegislator.manager
 
+import org.climatechangemakers.act.common.model.RepresentedArea
 import org.climatechangemakers.act.feature.findlegislator.model.MemberOfCongress
 
-fun interface MemberOfCongressManager {
-  suspend fun getMemberOfCongressForBioguide(bioguideId: String): MemberOfCongress
+interface MemberOfCongressManager {
+
+  suspend fun getMemberOfCongressForBioguide(
+    bioguideId: String
+  ): MemberOfCongress
+
+  suspend fun getMembersForCongressionalDistrict(
+    state: RepresentedArea,
+    district: Short,
+  ): List<MemberOfCongress>
 }

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GeocodioApiResult.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GeocodioApiResult.kt
@@ -1,6 +1,5 @@
 package org.climatechangemakers.act.feature.findlegislator.model
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable class GeocodioApiResult(
@@ -9,21 +8,4 @@ import kotlinx.serialization.Serializable
 
 @Serializable class GeocodeResult(
   val location: Location,
-  val fields: Fields,
-)
-
-@Serializable class Fields(
-  @SerialName("congressional_districts") val congressionalDistricts: List<CongressionalDistrict> = emptyList()
-)
-
-@Serializable class CongressionalDistrict(
-  @SerialName("current_legislators") val currentLegislators: List<GeocodioLegislator> = emptyList(),
-)
-
-@Serializable class GeocodioLegislator(
-  val references: LegislatorReferences,
-)
-
-@Serializable class LegislatorReferences(
-  @SerialName("bioguide_id") val bioguide: String,
 )

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GoogleCivicApiResult.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GoogleCivicApiResult.kt
@@ -1,0 +1,16 @@
+package org.climatechangemakers.act.feature.findlegislator.model
+
+import kotlinx.serialization.Serializable
+
+private val openCivicDataRegex = """ocd-division/country:us/state:[a-zA-Z]{2}/cd:(\d+)""".toRegex()
+
+@Serializable class GoogleCivicApiResult(
+  private val divisions: Map<String, Map<String, String>>,
+) {
+  val congressionalDistrict: Short get() = openCivicDataRegex
+    .matchEntire(divisions.keys.first())
+    ?.groups
+    ?.get(1)
+    ?.value
+    ?.toShort()!!
+}

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/MemberOfCongressDto.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/MemberOfCongressDto.kt
@@ -3,7 +3,7 @@ package org.climatechangemakers.act.feature.findlegislator.model
 import org.climatechangemakers.act.feature.lcvscore.model.LcvScore
 import kotlinx.serialization.Serializable
 
-@Serializable data class Legislator(
+@Serializable data class MemberOfCongressDto(
   val name: String,
   val bioguideId: String,
   val role: LegislatorRole,

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/service/GeocodioService.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/service/GeocodioService.kt
@@ -9,6 +9,5 @@ interface GeocodioService {
   @GET("geocode")
   suspend fun geocode(
     @Query("q") query: String,
-    @Query("fields") fields: List<String> = listOf("cd"),
   ): GeocodioApiResult
 }

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/service/GoogleCivicService.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/service/GoogleCivicService.kt
@@ -1,0 +1,16 @@
+package org.climatechangemakers.act.feature.findlegislator.service
+
+import org.climatechangemakers.act.feature.findlegislator.model.GoogleCivicApiResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface GoogleCivicService {
+
+  @GET("representatives")
+  suspend fun getCongressionalDistrict(
+    @Query("address") address: String,
+    @Query("levels") levels: String = "country",
+    @Query("roles") roles: String = "legislatorLowerBody",
+    @Query("includeOffices") includeOffices: Boolean = false,
+  ): GoogleCivicApiResult
+}

--- a/backend/src/main/sqldelight/org/climatechangemakers/act/database/MemberOfCongress.sq
+++ b/backend/src/main/sqldelight/org/climatechangemakers/act/database/MemberOfCongress.sq
@@ -17,3 +17,7 @@ CREATE TABLE member_of_congress (
 selectForBioguide:
 SELECT * FROM member_of_congress
 WHERE bioguide_id = :bioguideId;
+
+selectForCongressionalDistrict:
+SELECT * FROM member_of_congress
+WHERE state = :state AND (congressional_district = :congressionalDistrict OR congressional_district IS NULL);

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseMemberOfCongressManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseMemberOfCongressManagerTest.kt
@@ -14,19 +14,27 @@ class DatabaseMemberOfCongressManagerTest : TestContainerProvider() {
 
   private val manager = DatabaseMemberOfCongressManager(database, EmptyCoroutineContext)
 
-  @Test fun `select gets correct result`() = suspendTest {
-    insert(MemberOfCongress(
-      "a",
-      "a",
+  @Test fun `select for congressional district get house representative`() = suspendTest {
+    val expectedMember = MemberOfCongress(
+      "b",
+      "b",
       LegislatorRole.Representative,
-      RepresentedArea.NewJersey,
+      RepresentedArea.Virginia,
       1,
       LegislatorPoliticalParty.Republican,
       "555-555-5555",
-      "twitter1",
-      "foobar",
-    ))
+      "twitter2",
+      "barfoo",
+    )
 
+    insert(expectedMember)
+    assertEquals(
+      listOf(expectedMember),
+      manager.getMembersForCongressionalDistrict(RepresentedArea.Virginia, 1),
+    )
+  }
+
+  @Test fun `select for congressional district gets senators`() = suspendTest {
     val expectedMember = MemberOfCongress(
       "b",
       "b",
@@ -40,7 +48,14 @@ class DatabaseMemberOfCongressManagerTest : TestContainerProvider() {
     )
 
     insert(expectedMember)
-    assertEquals(expectedMember, manager.getMemberOfCongressForBioguide("b"))
+    assertEquals(
+      listOf(expectedMember),
+      manager.getMembersForCongressionalDistrict(RepresentedArea.Virginia, 1),
+    )
+  }
+
+  @Test fun `select for congressional district omits irrelevant content`() = suspendTest {
+
   }
 
   private fun insert(member: MemberOfCongress) = driver.execute(

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/FakeMemberOfCongressManager.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/FakeMemberOfCongressManager.kt
@@ -1,0 +1,38 @@
+package org.climatechangemakers.act.feature.findlegislator.manager
+
+import kotlinx.coroutines.channels.Channel
+import org.climatechangemakers.act.common.model.RepresentedArea
+import org.climatechangemakers.act.feature.findlegislator.model.LegislatorPoliticalParty
+import org.climatechangemakers.act.feature.findlegislator.model.LegislatorRole
+import org.climatechangemakers.act.feature.findlegislator.model.MemberOfCongress
+
+class FakeMemberOfCongressManager : MemberOfCongressManager {
+
+  val memberQueue: Channel<MemberOfCongress> = Channel(Channel.BUFFERED)
+  val memberListQueue: Channel<List<MemberOfCongress>> = Channel(Channel.BUFFERED)
+
+  override suspend fun getMemberOfCongressForBioguide(bioguideId: String): MemberOfCongress {
+    return memberQueue.tryReceive().getOrThrow()
+  }
+
+  override suspend fun getMembersForCongressionalDistrict(
+    state: RepresentedArea,
+    district: Short
+  ): List<MemberOfCongress> {
+    return memberListQueue.tryReceive().getOrThrow()
+  }
+
+  companion object {
+    val DEFAULT_MEMBER = MemberOfCongress(
+      bioguideId = "bioguide",
+      fullName = "Full name",
+      legislativeRole = LegislatorRole.Representative,
+      representedArea = RepresentedArea.Virginia,
+      congressionalDistrict = 1,
+      party = LegislatorPoliticalParty.Republican,
+      dcPhoneNumber = "(555) 555-5555",
+      twitterHandle = "foo",
+      cwcOfficeCode = "code",
+    )
+  }
+}

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GoogleCivicApiResultTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GoogleCivicApiResultTest.kt
@@ -1,0 +1,25 @@
+package org.climatechangemakers.act.feature.findlegislator.model
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class GoogleCivicApiResultTest {
+
+  @Test fun `civic api result can pase single digit congressional division from open civic data format`() {
+    val formatted = "ocd-division/country:us/state:va/cd:4"
+    val actual = GoogleCivicApiResult(mapOf(formatted to emptyMap())).congressionalDistrict
+    assertEquals(4, actual)
+  }
+
+  @Test fun `civic api result can pase single digit congressional division leading zero from open civic data format`() {
+    val formatted = "ocd-division/country:us/state:va/cd:04"
+    val actual = GoogleCivicApiResult(mapOf(formatted to emptyMap())).congressionalDistrict
+    assertEquals(4, actual)
+  }
+
+  @Test fun `civic api result can pase double digit congressional division from open civic data format`() {
+    val formatted = "ocd-division/country:us/state:va/cd:10"
+    val actual = GoogleCivicApiResult(mapOf(formatted to emptyMap())).congressionalDistrict
+    assertEquals(10, actual)
+  }
+}

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GoogleCivicApiResultTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/model/GoogleCivicApiResultTest.kt
@@ -5,19 +5,19 @@ import kotlin.test.assertEquals
 
 class GoogleCivicApiResultTest {
 
-  @Test fun `civic api result can pase single digit congressional division from open civic data format`() {
+  @Test fun `civic api result can parse single digit congressional division from open civic data format`() {
     val formatted = "ocd-division/country:us/state:va/cd:4"
     val actual = GoogleCivicApiResult(mapOf(formatted to emptyMap())).congressionalDistrict
     assertEquals(4, actual)
   }
 
-  @Test fun `civic api result can pase single digit congressional division leading zero from open civic data format`() {
+  @Test fun `civic api result can parse single digit congressional division leading zero from open civic data format`() {
     val formatted = "ocd-division/country:us/state:va/cd:04"
     val actual = GoogleCivicApiResult(mapOf(formatted to emptyMap())).congressionalDistrict
     assertEquals(4, actual)
   }
 
-  @Test fun `civic api result can pase double digit congressional division from open civic data format`() {
+  @Test fun `civic api result can parse double digit congressional division from open civic data format`() {
     val formatted = "ocd-division/country:us/state:va/cd:10"
     val actual = GoogleCivicApiResult(mapOf(formatted to emptyMap())).congressionalDistrict
     assertEquals(10, actual)

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/service/FakeGeocodioService.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/service/FakeGeocodioService.kt
@@ -8,7 +8,7 @@ class FakeGeocodioService(
 
   var capturedQuery: String? = null
 
-  override suspend fun geocode(query: String, fields: List<String>): GeocodioApiResult{
+  override suspend fun geocode(query: String): GeocodioApiResult{
     capturedQuery = query
     return fakeResultProvider()
   }

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/service/FakeGoogleCivicService.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/service/FakeGoogleCivicService.kt
@@ -1,0 +1,27 @@
+package org.climatechangemakers.act.feature.findlegislator.service
+
+import kotlinx.coroutines.channels.Channel
+import org.climatechangemakers.act.common.model.RepresentedArea
+import org.climatechangemakers.act.feature.findlegislator.model.GoogleCivicApiResult
+
+class FakeGoogleCivicService : GoogleCivicService {
+
+  val resultQueue = Channel<GoogleCivicApiResult>(Channel.BUFFERED)
+
+  override suspend fun getCongressionalDistrict(
+    address: String,
+    levels: String,
+    roles: String,
+    includeOffices: Boolean,
+  ): GoogleCivicApiResult = resultQueue.tryReceive().getOrThrow()
+
+  companion object {
+
+    fun buildApiResponse(
+      state: RepresentedArea,
+      district: Short,
+    ): GoogleCivicApiResult = GoogleCivicApiResult(
+      mapOf("ocd-division/country:us/state:${state.value}/cd:$district" to emptyMap())
+    )
+  }
+}

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/issue/manager/DatabaseIssueManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/issue/manager/DatabaseIssueManagerTest.kt
@@ -1,6 +1,7 @@
 package org.climatechangemakers.act.feature.issue.manager
 
 import org.climatechangemakers.act.common.model.RepresentedArea
+import org.climatechangemakers.act.feature.findlegislator.manager.FakeMemberOfCongressManager
 import org.climatechangemakers.act.feature.findlegislator.manager.MemberOfCongressManager
 import org.climatechangemakers.act.feature.findlegislator.model.LegislatorPoliticalParty
 import org.climatechangemakers.act.feature.findlegislator.model.LegislatorRole
@@ -18,19 +19,7 @@ import kotlin.test.assertFailsWith
 
 class DatabaseIssueManagerTest : TestContainerProvider() {
 
-  private val fakeMemberOfCongressManager = MemberOfCongressManager { bioguideId ->
-    MemberOfCongress(
-      bioguideId = bioguideId,
-      fullName = "name",
-      legislativeRole = LegislatorRole.Representative,
-      representedArea = RepresentedArea.Virginia,
-      congressionalDistrict = null,
-      party = LegislatorPoliticalParty.Democrat,
-      dcPhoneNumber = "1",
-      twitterHandle = "handle",
-      cwcOfficeCode = null,
-    )
-  }
+  private val fakeMemberOfCongressManager = FakeMemberOfCongressManager()
   private val issueManager = DatabaseIssueManager(fakeMemberOfCongressManager, database, EmptyCoroutineContext)
 
   @Test fun `getting focus issue returns most recently focused item`() = suspendTest {
@@ -115,6 +104,9 @@ class DatabaseIssueManagerTest : TestContainerProvider() {
 
   @Test fun `precomposed tweet is formatted correctly`() = suspendTest {
     val id1 = driver.insertIssue("issue", "This is a tweet to %s", "url.com")
+    fakeMemberOfCongressManager.memberQueue.send(
+      FakeMemberOfCongressManager.DEFAULT_MEMBER.copy(bioguideId = "id", twitterHandle = "handle")
+    )
     val tweet = issueManager.getPreComposedTweetForIssue(id1, listOf("id"))
     assertEquals(PreComposedTweetResponse("This is a tweet to @handle"), tweet)
   }

--- a/cloudformation/public-subnet-public-loadbalancer.yml
+++ b/cloudformation/public-subnet-public-loadbalancer.yml
@@ -81,6 +81,8 @@ Resources:
           Secrets:
             - Name: GEOCODIO_API_KEY
               ValueFrom: 'arn:aws:secretsmanager:us-west-2:207054523690:secret:GEOCODIO_API_KEY-9Q9NTK'
+            - Name: GOOGLE_CIVIC_API_KEY
+              ValueFrom: 'arn:aws:secretsmanager:us-west-2:207054523690:secret:GOOGLE_CIVIC_API_KEY-tDifo3'
             - Name: POSTGRES_PASSWORD
               ValueFrom: 'arn:aws:secretsmanager:us-west-2:207054523690:secret:POSTGRES_PASSWORD-GEMmif'
             - Name: POSTGRES_USER


### PR DESCRIPTION
This commit replaces Geocod.io as our source of congressional district
information. This is important because Geocod.io has a lot of
informational errors. Emails that are sent to an incorrect district are
rejected by CWC.

Unfortunately the Google Civic Information API does not expose GPS coordinates.
This is a separate, paid, service from Google.

Therefore, we now have two GIS dependencies. Google's will hopefully
give us correct congressional district data, and Geocodio will give us
GPS coordinates that we will continue to use for district office
lookups.
