### PR TITLE
Mark `member_of_congress.twitter_handle` nullable

### DIFF
--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseMemberOfCongressManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseMemberOfCongressManager.kt
@@ -30,4 +30,10 @@ class DatabaseMemberOfCongressManager @Inject constructor(
       mapper = ::MemberOfCongress,
     ).executeAsList()
   }
+
+  override suspend fun getTwitterHandlesForBioguides(
+    bioguides: List<String>,
+  ): List<String> = withContext(ioDispatcher) {
+    memberOfCongressQueries.selectTwitterHandlesForBioguides(bioguides).executeAsList()
+  }
 }

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/MemberOfCongressManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/MemberOfCongressManager.kt
@@ -13,4 +13,8 @@ interface MemberOfCongressManager {
     state: RepresentedArea,
     district: Short,
   ): List<MemberOfCongress>
+
+  suspend fun getTwitterHandlesForBioguides(
+    bioguides: List<String>,
+  ): List<String>
 }

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/MemberOfCongress.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/MemberOfCongress.kt
@@ -10,6 +10,6 @@ data class MemberOfCongress(
   val congressionalDistrict: Short?,
   val party: LegislatorPoliticalParty,
   val dcPhoneNumber: String,
-  val twitterHandle: String,
+  val twitterHandle: String?,
   val cwcOfficeCode: String?,
 )

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/MemberOfCongressDto.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/model/MemberOfCongressDto.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
   val role: LegislatorRole,
   val phoneNumbers: List<String>,
   val imageUrl: String?,
-  val twitter: String,
+  val twitter: String?,
   val area: LegislatorArea,
   val partyAffiliation: LegislatorPoliticalParty,
   val lcvScores: List<LcvScore>,

--- a/backend/src/main/sqldelight/migrations/V6__nullable_twitter_handle.sqm
+++ b/backend/src/main/sqldelight/migrations/V6__nullable_twitter_handle.sqm
@@ -1,0 +1,3 @@
+ALTER TABLE member_of_congress
+ALTER COLUMN twitter_handle
+DROP NOT NULL;

--- a/backend/src/main/sqldelight/org/climatechangemakers/act/database/MemberOfCongress.sq
+++ b/backend/src/main/sqldelight/org/climatechangemakers/act/database/MemberOfCongress.sq
@@ -10,7 +10,7 @@ CREATE TABLE member_of_congress (
   congressional_district SMALLINT,
   party VARCHAR AS LegislatorPoliticalParty NOT NULL,
   dc_phone_number VARCHAR NOT NULL,
-  twitter_handle VARCHAR NOT NULL,
+  twitter_handle VARCHAR,
   cwc_office_code VARCHAR
 );
 
@@ -21,3 +21,7 @@ WHERE bioguide_id = :bioguideId;
 selectForCongressionalDistrict:
 SELECT * FROM member_of_congress
 WHERE state = :state AND (congressional_district = :congressionalDistrict OR congressional_district IS NULL);
+
+selectTwitterHandlesForBioguides:
+SELECT twitter_handle FROM member_of_congress
+WHERE twitter_handle IS NOT NULL AND bioguide_id IN :bioguideIds;

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseMemberOfCongressManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseMemberOfCongressManagerTest.kt
@@ -58,6 +58,27 @@ class DatabaseMemberOfCongressManagerTest : TestContainerProvider() {
 
   }
 
+  @Test fun `select twitter handles omits null values`() = suspendTest {
+    val expectedMember = MemberOfCongress(
+      "b",
+      "b",
+      LegislatorRole.Senator,
+      RepresentedArea.Virginia,
+      null,
+      LegislatorPoliticalParty.Republican,
+      "555-555-5555",
+      "twitter2",
+      "barfoo",
+    )
+
+    insert(expectedMember)
+    insert(expectedMember.copy(bioguideId = "a", twitterHandle = null))
+    assertEquals(
+      expected = listOf("twitter2"),
+      actual = manager.getTwitterHandlesForBioguides(listOf("a", "b"))
+    )
+  }
+
   private fun insert(member: MemberOfCongress) = driver.execute(
     0, "INSERT INTO member_of_congress VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)", 9
   ) {

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/FakeMemberOfCongressManager.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/FakeMemberOfCongressManager.kt
@@ -10,6 +10,7 @@ class FakeMemberOfCongressManager : MemberOfCongressManager {
 
   val memberQueue: Channel<MemberOfCongress> = Channel(Channel.BUFFERED)
   val memberListQueue: Channel<List<MemberOfCongress>> = Channel(Channel.BUFFERED)
+  val twitterHandlesQueue: Channel<List<String>> = Channel(Channel.BUFFERED)
 
   override suspend fun getMemberOfCongressForBioguide(bioguideId: String): MemberOfCongress {
     return memberQueue.tryReceive().getOrThrow()
@@ -20,6 +21,10 @@ class FakeMemberOfCongressManager : MemberOfCongressManager {
     district: Short
   ): List<MemberOfCongress> {
     return memberListQueue.tryReceive().getOrThrow()
+  }
+
+  override suspend fun getTwitterHandlesForBioguides(bioguides: List<String>): List<String> {
+    return twitterHandlesQueue.tryReceive().getOrThrow()
   }
 
   companion object {

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/issue/manager/DatabaseIssueManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/issue/manager/DatabaseIssueManagerTest.kt
@@ -104,9 +104,7 @@ class DatabaseIssueManagerTest : TestContainerProvider() {
 
   @Test fun `precomposed tweet is formatted correctly`() = suspendTest {
     val id1 = driver.insertIssue("issue", "This is a tweet to %s", "url.com")
-    fakeMemberOfCongressManager.memberQueue.send(
-      FakeMemberOfCongressManager.DEFAULT_MEMBER.copy(bioguideId = "id", twitterHandle = "handle")
-    )
+    fakeMemberOfCongressManager.twitterHandlesQueue.send(listOf("handle"))
     val tweet = issueManager.getPreComposedTweetForIssue(id1, listOf("id"))
     assertEquals(PreComposedTweetResponse("This is a tweet to @handle"), tweet)
   }

--- a/frontend/src/common/Components/LegislatorCard/LegislatorCard.tsx
+++ b/frontend/src/common/Components/LegislatorCard/LegislatorCard.tsx
@@ -56,9 +56,11 @@ export default function LegislatorCard({ legislator, call }: Props) {
                                 {legislator.area.districtNumber ? `-${legislator.area.districtNumber}` : ""}
                             </Badge>
                         </div>
-                        <div className="text-purple mb-2 fs-7 fw-bold" ref={legislatorContainerRef}>
-                            @{legislator.twitter}
-                        </div>
+                        {legislator.twitter != null && (
+                            <div className="text-purple mb-2 fs-7 fw-bold" ref={legislatorContainerRef}>
+                                @{legislator.twitter}
+                            </div>
+                        )}
                         {legislator.lcvScores.length > 0 && (
                             <OverlayTrigger
                                 placement="bottom"


### PR DESCRIPTION
In preparation for automatic Member of Congress data updates,
we need to align our data schema with what's available from
the United States Github Organization.

https://github.com/unitedstates/congress-legislators

Some MoC don't have a Twitter account, and therefore we should
align ourselves accordingly. 

References #317 