### PR TITLE
Add null constraint to `district_office.phone_number`

### DIFF
--- a/backend/src/main/sqldelight/migrations/V7__non_null_district_office_phone_number.sqm
+++ b/backend/src/main/sqldelight/migrations/V7__non_null_district_office_phone_number.sqm
@@ -1,0 +1,6 @@
+DELETE FROM district_office
+WHERE phone_number IS NULL;
+
+ALTER TABLE district_office
+ALTER COLUMN phone_number
+SET NOT NULL;

--- a/backend/src/main/sqldelight/org/climatechangemakers/act/database/DistrictOffice.sq
+++ b/backend/src/main/sqldelight/org/climatechangemakers/act/database/DistrictOffice.sq
@@ -1,6 +1,6 @@
 CREATE TABLE district_office (
   bioguide_id VARCHAR NOT NULL REFERENCES member_of_congress(bioguide_id),
-  phone_number VARCHAR,
+  phone_number VARCHAR NOT NULL,
   lat DOUBLE PRECISION,
   long DOUBLE PRECISION
 );
@@ -8,7 +8,7 @@ CREATE TABLE district_office (
 selectClosestDistrictOfficePhoneNumber:
 SELECT phone_number
 FROM district_office
-WHERE phone_number IS NOT NULL AND bioguide_id = :bioguideId
+WHERE bioguide_id = :bioguideId
 ORDER BY
 (2 * 6371 * ASIN(
     SQRT(

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseDistrictOfficeManagerTest.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseDistrictOfficeManagerTest.kt
@@ -47,12 +47,6 @@ class DatabaseDistrictOfficeManagerTest : TestContainerProvider() {
     )
   }
 
-  @Test fun `returns null with no eligable phone numbers`() = suspendTest {
-    driver.insertMemberOfCongress(DEFAULT_MEMBER_OF_CONGRESS.copy(bioguideId = "hello"))
-    insert("hello", null, 10.0, 10.0)
-    assertNull(manager.getNearestDistrictOfficePhoneNumber("hello", Location(1.0, 1.0)))
-  }
-
   @Test fun `only return district office for related bioguides`() = suspendTest {
     driver.insertMemberOfCongress(DEFAULT_MEMBER_OF_CONGRESS.copy(bioguideId = "hello"))
     driver.insertMemberOfCongress(DEFAULT_MEMBER_OF_CONGRESS.copy(bioguideId = "goodbye"))
@@ -65,7 +59,7 @@ class DatabaseDistrictOfficeManagerTest : TestContainerProvider() {
     )
   }
 
-  private fun insert(bioguideId: String, phoneNumber: String?, lat: Double?, long: Double?) {
+  private fun insert(bioguideId: String, phoneNumber: String, lat: Double?, long: Double?) {
     driver.execute(0, "INSERT INTO district_office VALUES(?, ?, ?, ?);", 4) {
       bindString(1, bioguideId)
       bindString(2, phoneNumber)


### PR DESCRIPTION
The only piece of information which is useful to Changemaker's is the
district office's phone number. To aid in the automatic processes for
updating this data, this commit makes that column non-null.

References #317
