### PR TITLE
Make `first_name`, `last_name`, and `term_end` not null

### DIFF
--- a/backend/src/main/sqldelight/migrations/V11__not_null_MoC_columns.sqm
+++ b/backend/src/main/sqldelight/migrations/V11__not_null_MoC_columns.sqm
@@ -1,0 +1,14 @@
+DELETE FROM member_of_congress
+WHERE term_end IS NULL OR first_name IS NULL OR last_name IS NULL;
+
+ALTER TABLE member_of_congress
+ALTER COLUMN term_end
+SET NOT NULL;
+
+ALTER TABLE member_of_congress
+ALTER COLUMN first_name
+SET NOT NULL;
+
+ALTER TABLE member_of_congress
+ALTER COLUMN last_name
+SET NOT NULL;

--- a/backend/src/main/sqldelight/org/climatechangemakers/act/database/MemberOfCongress.sq
+++ b/backend/src/main/sqldelight/org/climatechangemakers/act/database/MemberOfCongress.sq
@@ -5,8 +5,8 @@ import org.climatechangemakers.act.feature.findlegislator.model.LegislatorPoliti
 CREATE TABLE member_of_congress (
   bioguide_id VARCHAR NOT NULL PRIMARY KEY,
   full_name VARCHAR NOT NULL,
-  first_name VARCHAR,
-  last_name VARCHAR,
+  first_name VARCHAR NOT NULL,
+  last_name VARCHAR NOT NULL,
   legislative_role VARCHAR AS LegislatorRole NOT NULL,
   state VARCHAR AS RepresentedArea NOT NULL,
   congressional_district SMALLINT,
@@ -14,7 +14,7 @@ CREATE TABLE member_of_congress (
   dc_phone_number VARCHAR NOT NULL,
   twitter_handle VARCHAR,
   cwc_office_code VARCHAR,
-  term_end DATE
+  term_end DATE NOT NULL
 );
 
 selectForBioguide:

--- a/backend/src/test/kotlin/org/climatechangemakers/act/feature/util/SqlDriverExtensions.kt
+++ b/backend/src/test/kotlin/org/climatechangemakers/act/feature/util/SqlDriverExtensions.kt
@@ -48,11 +48,13 @@ fun SqlDriver.insertMemberOfCongress(
     |  dc_phone_number,
     |  twitter_handle,
     |  cwc_office_code,
-    |  term_end
+    |  term_end,
+    |  first_name,
+    |  last_name
     |)
-    |VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    |VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   """.trimMargin(),
-  parameters = 10,
+  parameters = 12,
 ) {
   bindString(1, member.bioguideId)
   bindString(2, member.fullName)
@@ -64,6 +66,8 @@ fun SqlDriver.insertMemberOfCongress(
   bindString(8, member.twitterHandle)
   bindString(9, member.cwcOfficeCode)
   (this as JdbcPreparedStatement).bindObject(10, termEnd.toJavaLocalDate())
+  bindString(11, "")
+  bindString(12, "")
 }
 
 val DEFAULT_MEMBER_OF_CONGRESS = MemberOfCongress(


### PR DESCRIPTION
Prior to this commit, we have 5 or so rows in our `member_of_congress`
table that didn't have this information populated. This is because
this data is stale.

We now have an automated system to keep our MoC data updated. Rows where
this data was null have resigned/died/left congress prior to this
automation being in place.

We do not currently have any data referencing these members of congress,
so deleting their data won't cascade.
