### PR TITLE
Only select currently serving Members of Congress

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
 
     implementation(libs.logback.classic)
 
+    implementation(libs.kotlinx.datetime)
+
     implementation(libs.dagger)
     kapt(libs.dagger.compiler)
 

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 dagger = "2.41"
 kotlin = "1.6.21"
 kotlinx-serialization = "1.3.2"
+kotlinx-datetime = "0.3.2"
 ktor = "1.6.7"
 logback = "1.2.11"
 postgresql = "42.3.3"
@@ -21,6 +22,7 @@ ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor"
 ktor-server-tests = { module = "io.ktor:ktor-server-tests", version.ref = "ktor" }
 
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 

--- a/backend/src/main/kotlin/org/climatechangemakers/act/di/ApiComponent.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/di/ApiComponent.kt
@@ -17,6 +17,7 @@ import javax.inject.Singleton
   LoggerModule::class,
   ServiceModule::class,
   SerializationModule::class,
+  ClockModule::class,
 ])
 interface ApiComponent {
 

--- a/backend/src/main/kotlin/org/climatechangemakers/act/di/ClockModule.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/di/ClockModule.kt
@@ -1,0 +1,10 @@
+package org.climatechangemakers.act.di
+
+import dagger.Module
+import dagger.Provides
+import kotlinx.datetime.Clock
+
+@Module object ClockModule {
+
+  @Provides fun providesClock(): Clock = Clock.System
+}

--- a/backend/src/main/kotlin/org/climatechangemakers/act/di/CoroutineModule.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/di/CoroutineModule.kt
@@ -3,7 +3,6 @@ package org.climatechangemakers.act.di
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.Dispatchers
-import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 @Module object CoroutineModule {

--- a/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseMemberOfCongressManager.kt
+++ b/backend/src/main/kotlin/org/climatechangemakers/act/feature/findlegislator/manager/DatabaseMemberOfCongressManager.kt
@@ -1,17 +1,21 @@
 package org.climatechangemakers.act.feature.findlegislator.manager
 
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toJavaLocalDate
+import kotlinx.datetime.todayAt
 import org.climatechangemakers.act.common.model.RepresentedArea
 import org.climatechangemakers.act.database.Database
 import org.climatechangemakers.act.di.Io
-import org.climatechangemakers.act.feature.findlegislator.model.LegislatorRole
 import org.climatechangemakers.act.feature.findlegislator.model.MemberOfCongress
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
 class DatabaseMemberOfCongressManager @Inject constructor(
   database: Database,
-  @Io private val ioDispatcher: CoroutineContext
+  private val clock: Clock,
+  @Io private val ioDispatcher: CoroutineContext,
 ) : MemberOfCongressManager {
 
   private val memberOfCongressQueries = database.memberOfCongressQueries
@@ -27,6 +31,7 @@ class DatabaseMemberOfCongressManager @Inject constructor(
     memberOfCongressQueries.selectForCongressionalDistrict(
       state = state,
       congressionalDistrict = district,
+      today = clock.todayAt(TimeZone.UTC).toJavaLocalDate(),
       mapper = ::MemberOfCongress,
     ).executeAsList()
   }

--- a/backend/src/main/sqldelight/org/climatechangemakers/act/database/MemberOfCongress.sq
+++ b/backend/src/main/sqldelight/org/climatechangemakers/act/database/MemberOfCongress.sq
@@ -43,7 +43,13 @@ SELECT
   twitter_handle,
   cwc_office_code
 FROM member_of_congress
-WHERE state = :state AND (congressional_district = :congressionalDistrict OR congressional_district IS NULL);
+WHERE (
+  state = :state
+  AND
+  (congressional_district = :congressionalDistrict OR congressional_district IS NULL)
+  AND
+  term_end >= :today
+);
 
 selectTwitterHandlesForBioguides:
 SELECT twitter_handle FROM member_of_congress


### PR DESCRIPTION
Now that we're tracking more Members of Congress than are currently
serving, we need to use `member_of_congress.term_end` to determine if a
given member is currently serving.

We should only be selecting MoC who are currently serving, as they're
the people who are meant to receive correspondence.
